### PR TITLE
Release v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.1.14",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
`0.1.14` → **`0.2.0`**

## Why minor, not patch

Two changes break consumers, and on `0.x` npm treats `^0.1.x` and `^0.2.x` as
incompatible — that boundary is the only protection they get:

- **`TokenProvider.getToken()` rejects** where it used to resolve
  `{ success: false }`. Anyone branching on `result.success` after a failure now
  needs a `catch`.
- **`LocationServiceException.statusCode` is optional.** Failures that never
  reached the server — network, timeout, abort — genuinely have no status, and
  pretending otherwise meant lying with a `0`.

## What is in it

- `a2cd9de` CodeQL action to v4; README type annotations
- `b2d9a18` A real transport: timeouts, cancellation, retry, typed errors
  (#4, #5, #9)

The substance of `b2d9a18`: one shared `src/transport/` replacing two
byte-identical copies of the same error-parsing code; `send()` gaining
`signal` / `timeoutMs` / `retry` with a policy that separates "never arrived"
(502/503/504, retry) from "the server broke on this request" (500, do not);
`TokenProvider` telling a 503 store outage apart from a 401 rather than
flattening both into "invalid credentials"; and the provider singleton key
finally including the **secret**, so rotating one takes effect without a process
restart.

Also in this release, from the same merge: the `pre-commit` hook that deleted
`package-lock.json` and auto-staged a regenerated one on every commit is gone,
`release.yml` is deleted in favour of `npm version` on a branch, `publish.yml`
waits for `build.yml` to pass, and `build.yml` runs lint for the first time.

## Verification

Preflight and gate, on this exact tree:

| Check | Result |
|---|---|
| clean tree, on `main`, fast-forwarded | yes |
| `npm ci --dry-run` lockfile drift | none |
| lint | pass |
| tests | 17 passed |
| build | pass |

The commit is **exactly two files** — `package.json` and `package-lock.json` —
made by `npm version minor`, so the bump, the commit and the signed tag `v0.2.0`
come from one atomic step and cannot disagree.

## After this publishes

`@chaosity/location-client-react` still declares `^0.1.14`, which **cannot
resolve `0.2.0`**. Its range bump belongs in its own release PR, together with
its version bump — releasing it before that would publish a package silently
still using the old client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
