### PR TITLE
One token-refresh threshold, and take expiry from the token itself

### DIFF
--- a/src/auth/TokenProvider.ts
+++ b/src/auth/TokenProvider.ts
@@ -1,6 +1,7 @@
 import debug from 'debug'
 import { LocationServiceException } from '../errors/LocationServiceException'
 import { requestJson } from '../transport/http'
+import { TOKEN_REFRESH_BUFFER_SECONDS, readTokenExpiry } from './tokenRefresh'
 
 const log = debug('location-client:auth')
 
@@ -149,9 +150,13 @@ export class TokenProvider {
     }
 
     this.cachedToken = data.access_token
-    // Prefer the absolute expires_at (ms); fall back to expires_in (seconds).
+    // The token's own `exp` claim first — it is the only value that cannot
+    // disagree with what the API will actually accept. `expires_at` and
+    // `expires_in` are what the response CLAIMS, and are kept as fallbacks.
     this.cachedExpiresAt =
-      data.expires_at ?? Date.now() + (data.expires_in ?? 900) * 1000
+      readTokenExpiry(data.access_token) ??
+      data.expires_at ??
+      Date.now() + (data.expires_in ?? 900) * 1000
 
     log(
       'Token acquired successfully (expires in %ds)',
@@ -164,7 +169,7 @@ export class TokenProvider {
     }
   }
 
-  private isExpired(bufferSeconds = 60): boolean {
+  private isExpired(bufferSeconds = TOKEN_REFRESH_BUFFER_SECONDS): boolean {
     if (!this.cachedExpiresAt) return true
     return Date.now() >= this.cachedExpiresAt - bufferSeconds * 1000
   }

--- a/src/auth/tokenRefresh.ts
+++ b/src/auth/tokenRefresh.ts
@@ -1,0 +1,53 @@
+/**
+ * How long before expiry a token is treated as needing replacement.
+ *
+ * ONE number, used by both sides: the server-side `TokenProvider` deciding
+ * whether its cached token is still good, and the React provider deciding
+ * whether to ask for a new one. Both apply it to the same `exp` claim, so they
+ * cannot reach different answers about the same token.
+ *
+ * It used to be two separate `60`s — a private literal in `isExpired()` and a
+ * public `refreshBuffer` prop default — with nothing tying them together. On
+ * 2026-08-23 a consumer passed `refreshBuffer={800}` against a 900 s token: the
+ * client judged it stale after 100 s, the server still considered it fresh for
+ * another 840 s and returned the same one, and the client asked again
+ * immediately — roughly 110 requests per second from an idle page.
+ *
+ * Not configurable per consumer, deliberately. A settable client-side buffer is
+ * precisely what allowed that disagreement, and no amount of capping or backing
+ * off fixes it as cleanly as the two sides simply sharing the number.
+ */
+export const TOKEN_REFRESH_BUFFER_SECONDS = 60
+
+/**
+ * Read the `exp` claim out of a JWT, in milliseconds.
+ *
+ * The expiry is IN THE TOKEN, so neither side needs to be told it. Both used to
+ * take it on trust from elsewhere — the server from the response body's
+ * `expires_at`, the React provider from whatever `getConfig` returned, falling
+ * back to inventing `Date.now() + 900_000` when that was absent. An invented
+ * expiry is how the two ended up disagreeing about the same token.
+ *
+ * Deliberately NOT verified. This is only used to decide *when to refresh*;
+ * nothing is authorised on the strength of it, and the API verifies the
+ * signature on every request regardless. Trusting `exp` for scheduling is safe
+ * in a way that trusting it for access would not be.
+ *
+ * Returns undefined for anything unparseable, so callers keep their fallback.
+ */
+export function readTokenExpiry(token: string | undefined): number | undefined {
+  if (!token) return undefined
+  const payload = token.split('.')[1]
+  if (!payload) return undefined
+  try {
+    const base64 = payload.replace(/-/g, '+').replace(/_/g, '/')
+    const json =
+      typeof atob === 'function'
+        ? atob(base64)
+        : Buffer.from(base64, 'base64').toString('utf8')
+    const exp = JSON.parse(json)?.exp
+    return typeof exp === 'number' ? exp * 1000 : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,12 @@ export type { SendOptions } from './client/GeoPlacesClient'
 export { DEFAULT_MAX_ATTEMPTS, DEFAULT_TIMEOUT_MS } from './transport/http'
 export type { RequestOptions } from './transport/http'
 
+// Token refresh policy — shared by the server provider and the React provider
+export {
+  TOKEN_REFRESH_BUFFER_SECONDS,
+  readTokenExpiry,
+} from './auth/tokenRefresh'
+
 // Errors
 export { LocationServiceException } from './errors/LocationServiceException'
 export type { LocationServiceExceptionOptions } from './errors/LocationServiceException'

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  TOKEN_REFRESH_BUFFER_SECONDS,
+  readTokenExpiry,
+} from '../src/auth/tokenRefresh'
 import { LocationServiceException } from '../src/errors/LocationServiceException'
 import { parseErrorResponse, parseRetryAfter } from '../src/transport/errors'
 import { backoffMs, requestJson } from '../src/transport/http'
@@ -202,5 +206,31 @@ describe('backoff', () => {
     expect(backoffMs(1, () => 1)).toBe(500)
     expect(backoffMs(10, () => 1)).toBe(4000) // capped
     expect(backoffMs(3, () => 0)).toBe(0) // full jitter can pick zero
+  })
+})
+
+describe('token refresh policy is one number, and expiry comes from the token', () => {
+  /**
+   * The server provider and the React provider used to carry separate `60`s —
+   * a private literal in `isExpired()` and a public prop default — with nothing
+   * tying them together. When they disagreed, the client asked for a token
+   * fresher than the server would mint, got the same one back, and asked again
+   * immediately: ~110 requests per second from an idle page on 2026-08-23.
+   */
+  it('exposes one buffer for both sides to share', () => {
+    expect(TOKEN_REFRESH_BUFFER_SECONDS).toBe(60)
+  })
+
+  it('reads the expiry out of the token rather than being told it', () => {
+    const exp = Math.floor(Date.now() / 1000) + 900
+    const token = `${btoa('{"alg":"HS256"}')}.${btoa(JSON.stringify({ exp }))}.sig`
+    expect(readTokenExpiry(token)).toBe(exp * 1000)
+  })
+
+  it('returns undefined for anything unparseable, so callers keep a fallback', () => {
+    expect(readTokenExpiry(undefined)).toBeUndefined()
+    expect(readTokenExpiry('not-a-jwt')).toBeUndefined()
+    expect(readTokenExpiry('a.b.c')).toBeUndefined()
+    expect(readTokenExpiry(`x.${btoa('{"no":"exp"}')}.y`)).toBeUndefined()
   })
 })


### PR DESCRIPTION
## The bug this closes

`client-react@0.2.0` — published ~an hour ago — can spin at **~110 requests per
second from a completely idle page**. Measured against the testbed on
2026-08-23:

| provider | `refreshBuffer` | `getConfig` calls in 8 s idle |
|---|---|---|
| `0.1.19` | 800 | **0** |
| `0.2.0` | 800 | **~900** |
| `0.2.0` | 60 | **0** |

**Why.** The two sides each owned their own `60` — a private literal in
`TokenProvider.isExpired()` and a public `refreshBuffer` prop default — with
nothing tying them together, and each derived the token's expiry from a
*different source*.

A consumer passed `refreshBuffer={800}` against a 900 s token. The browser judged
it stale after 100 s. But `getClientConfig` on the server only re-mints within
**60 s** of expiry, so it returned the *same* token. The browser judged it stale
again and asked immediately. Neither side was wrong on its own terms; they simply
could not agree about the same token.

The old provider never spun because it refreshed only inside `send` — the same
misconfiguration just meant a redundant refresh per call, bounded by user actions.
Making refresh proactive turned a latent disagreement into a hot loop.

## The fix

**One number.** `TOKEN_REFRESH_BUFFER_SECONDS = 60`, exported, used by
`isExpired()` and — in the matching `client-react` release — by the provider.
Deliberately **not** per-consumer settable: a settable client-side buffer is
exactly what allowed the disagreement.

**One source of expiry.** `readTokenExpiry()` reads the `exp` claim out of the
JWT. The expiry is *in the token*, so neither side needs to be told it.
`TokenProvider` previously trusted `expires_at` from the response body; the React
provider invented `Date.now() + 900_000` when `getConfig` did not supply one. An
invented expiry is how they ended up disagreeing.

It is **not verified**, on purpose: it decides only *when to refresh*, nothing is
authorised on the strength of it, and the API verifies the signature on every
request regardless.

**No caps, floors or back-off.** Those were written and then deleted. They defend
against a disagreement that sharing the number removes outright — capping the
symptom rather than fixing the cause.

## Verification

20 tests (3 new). More usefully, this was verified **end to end before
publishing**, using `npm pack` tarballs of this build and the matching
`client-react` installed into the testbed — the real artefacts, `files`/`exports`
included, not `npm link`:

| Check | Result |
|---|---|
| `getConfig` calls, 15 s idle | **4 total, delta 0** (was ~110/second) |
| autocomplete → GetPlace | 200, 200 |
| map: descriptor, sprites, tiles, DEM, glyphs | all 200, flew to z12 |
| console errors | **0** |

That local-first loop is the process change worth keeping: the spin reached npm
because `0.2.0` was verified only by unit tests and a stale dev server.

## Reviewer notes

- **`client-react` cannot build until this publishes.** It imports both new
  exports, and the published `0.2.0` tarball does not contain them — I checked
  the tarball rather than assuming. Order is: this → `client-react@0.2.1`
  (range → `^0.2.1`) → `address-form`.
- Wants a **patch**: purely additive, nothing removed or changed in signature.
- The pre-existing `resourceType` eslint *warning* is untouched — unrelated, and
  it does not fail the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
