### PR TITLE
Release v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
`0.2.0` → **`0.2.1`**

## Why patch

Purely additive. Two new exports, `isExpired()` switched to the shared constant,
and expiry now preferred from the token's `exp` claim. No signature changed,
nothing removed, no behaviour a consumer depends on altered.

## What is in it

`6ec8fcb` — one token-refresh threshold, and take expiry from the token itself.

It closes a spin that `client-react@0.2.0` shipped: **~110 requests per second
from a completely idle page**. The two providers each owned their own `60` — a
private literal in `TokenProvider.isExpired()` and a public `refreshBuffer` prop
default — and each derived the token's expiry from a *different source*. A
consumer passing `refreshBuffer={800}` against a 900 s token had the browser
judging it stale after 100 s, while `getClientConfig` only re-mints within 60 s
of expiry and kept returning the same token.

- **`TOKEN_REFRESH_BUFFER_SECONDS`** — one exported number for both sides, not
  per-consumer settable. A settable client-side buffer is exactly what allowed
  the disagreement.
- **`readTokenExpiry()`** — reads `exp` from the JWT. The expiry is *in the
  token*, so neither side needs to be told it. Not verified, deliberately: it
  decides only *when to refresh*, and the API verifies the signature on every
  request regardless.

No caps, floors or back-off — those were written and deleted, because they cap
the symptom rather than removing the cause.

## Verification

| Check | Result |
|---|---|
| clean tree, on `main`, fast-forwarded | yes |
| `npm ci --dry-run` lockfile drift | none |
| lint | pass |
| tests | 20 passed |
| build | pass |

And end-to-end **before** publishing, using `npm pack` tarballs installed into
the testbed — the real artefacts, `files`/`exports` included:

| Check | Result |
|---|---|
| `getConfig` calls, 15 s idle | **4 total, delta 0** (was ~110/second) |
| autocomplete → GetPlace | 200, 200 |
| map: descriptor, sprites, tiles, DEM, glyphs | all 200 |
| console errors | **0** |

The release commit is `package.json` + `package-lock.json` only, made by
`npm version patch`, so the bump, the commit and the signed tag `v0.2.1` come
from one atomic step.

## This unblocks the rest

`client-react` **cannot build** until this is on npm — it imports both new
exports and the published `0.2.0` tarball does not contain them. Order from
here: this → `client-react@0.2.1` (range → `^0.2.1`) → `address-form@0.2.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
