### PR TITLE
Stop paying for data we discard, and stop discarding position we need (#3)

### DIFF
--- a/src/adapters/GeoPlaces.ts
+++ b/src/adapters/GeoPlaces.ts
@@ -7,7 +7,6 @@ import {
   type GetPlaceResponse,
   ReverseGeocodeCommand,
   type ReverseGeocodeResponse,
-  SuggestAdditionalFeature,
   SuggestCommand,
   type SuggestResponse,
 } from '@aws-sdk/client-geo-places'
@@ -35,13 +34,75 @@ const log = debug('location-client:geocoder')
  *
  * Implements MaplibreGeocoderApi interface for compatibility with @maplibre/maplibre-gl-geocoder
  */
+/**
+ * Extra GetPlace detail, and what each one costs (#3 / T19).
+ *
+ * Measured against Amazon Location on 2026-08-25 by requesting each feature
+ * alone and reading the pricing bucket back:
+ *
+ *   (none)              -> Core      $0.50/1k
+ *   SecondaryAddresses  -> Core      $0.50/1k
+ *   Access              -> Advanced  $1.50/1k
+ *   TimeZone            -> Advanced  $1.50/1k
+ *   Contact             -> Advanced  $1.50/1k
+ *
+ * `secondaryAddresses` is therefore free in bucket terms and the others triple
+ * the price of every lookup. They are opt-in for that reason, not because the
+ * data is unwelcome.
+ *
+ * Worth knowing before enabling `contact`: for a street address it costs
+ * Advanced and returns no contact field at all — only points of interest carry
+ * one. On an address-completion flow that is 3x the price for nothing.
+ */
+export interface GeoPlacesDetailOptions {
+  /** Entrance/exit points. Moves the request to the Advanced bucket. */
+  access?: boolean
+  /** Unit and sub-address detail. Stays in the Core bucket — free to enable. */
+  secondaryAddresses?: boolean
+  /** Phone/website, POIs only. Moves the request to the Advanced bucket. */
+  contact?: boolean
+  /** IANA zone and offset. Moves the request to the Advanced bucket. */
+  timeZone?: boolean
+}
+
+export interface GeoPlacesOptions {
+  /**
+   * Extra detail on `searchByPlaceId`. Default: none, which keeps every
+   * lookup in the Core bucket.
+   */
+  details?: GeoPlacesDetailOptions
+}
+
 export class GeoPlaces implements MaplibreGeocoderApi {
   private client: GeoPlacesClient
   private map: Map
+  private details: GeoPlacesDetailOptions
 
-  constructor(client: GeoPlacesClient, map: Map) {
+  constructor(
+    client: GeoPlacesClient,
+    map: Map,
+    options: GeoPlacesOptions = {},
+  ) {
     this.client = client
     this.map = map
+    this.details = options.details ?? {}
+  }
+
+  /**
+   * Build the AdditionalFeatures list from the opt-ins, or omit it entirely.
+   *
+   * Returning `undefined` rather than `[]` matters: an empty array is still a
+   * field on the request, and the point is to send nothing.
+   */
+  private detailFeatures(): GetPlaceAdditionalFeature[] | undefined {
+    const features: GetPlaceAdditionalFeature[] = []
+    if (this.details.access) features.push(GetPlaceAdditionalFeature.ACCESS)
+    if (this.details.secondaryAddresses)
+      features.push(GetPlaceAdditionalFeature.SECONDARY_ADDRESSES)
+    if (this.details.contact) features.push(GetPlaceAdditionalFeature.CONTACT)
+    if (this.details.timeZone)
+      features.push(GetPlaceAdditionalFeature.TIME_ZONE)
+    return features.length ? features : undefined
   }
 
   private normalizeLanguage(language?: string | string[]): string {
@@ -128,7 +189,18 @@ export class GeoPlaces implements MaplibreGeocoderApi {
       BiasPosition: biasPosition,
       MaxResults: config.limit || 5,
       Language: this.normalizeLanguage(config.language),
-      AdditionalFeatures: [SuggestAdditionalFeature.CORE],
+      // No AdditionalFeatures (#3 / T19).
+      //
+      // This used to send `[Core]`, which put every keystroke in the Core
+      // bucket at $0.50/1k. The only thing Core adds to a Suggest response is
+      // `Highlights`, and this adapter reads `Title` and `Place.PlaceId` —
+      // nothing else. Verified against Amazon Location on 2026-08-25:
+      //
+      //   with [Core] -> bucket Core   keys: Title, ..., Place, Highlights
+      //   without     -> bucket Label  keys: Title, ..., Place
+      //
+      // Same two fields, $0.20/1k instead of $0.50. Suggest fires per
+      // keystroke, so it is the highest-volume call the library makes.
       ...(config.countries || config.bbox
         ? {
             Filter: {
@@ -169,15 +241,14 @@ export class GeoPlaces implements MaplibreGeocoderApi {
   ): Promise<MaplibreGeocoderPlaceResults> {
     log('searchByPlaceId placeId=%s', config.query)
 
+    // Opt-in rather than always-on (#3 / T19). Requesting all four put every
+    // lookup in the Advanced bucket at $1.50/1k; the default now sends none
+    // and stays in Core at $0.50. Callers that want the detail ask for it.
+    const additionalFeatures = this.detailFeatures()
     const command = new GetPlaceCommand({
       PlaceId: config.query as string,
       Language: this.normalizeLanguage(config.language),
-      AdditionalFeatures: [
-        GetPlaceAdditionalFeature.ACCESS,
-        GetPlaceAdditionalFeature.SECONDARY_ADDRESSES,
-        GetPlaceAdditionalFeature.CONTACT,
-        GetPlaceAdditionalFeature.TIME_ZONE,
-      ],
+      ...(additionalFeatures ? { AdditionalFeatures: additionalFeatures } : {}),
     })
 
     const response = (await this.client.send(command)) as GetPlaceResponse

--- a/src/client/GeoPlacesClient.ts
+++ b/src/client/GeoPlacesClient.ts
@@ -4,6 +4,8 @@ import type { RequestOptions } from '../transport/http'
 import { requestJson } from '../transport/http'
 import type { ClientConfig, GeoPlacesCommand } from '../types'
 import { roundPositionFields } from '../utils/roundPosition'
+import type { AppConfigClaims } from '../utils/tokenClaims'
+import { readAppConfigClaims } from '../utils/tokenClaims'
 
 const log = debug('location-client:api')
 
@@ -27,6 +29,25 @@ export class GeoPlacesClient {
   }
 
   /**
+   * This application's own configuration, as carried on the access token
+   * (api#65) — bias precision, and the countries it is scoped to.
+   *
+   * Provided so an application can SHOW its own settings: populate a country
+   * selector with the markets it actually serves, label a settings screen,
+   * and so on. Being a few minutes stale is cosmetic for that.
+   *
+   * It is not an entitlement check. See AppConfigClaims for why acting on
+   * `countries` client-side makes requests fail that would otherwise succeed.
+   *
+   * Returns `{}` when the token carries no application config, which is the
+   * case until one is configured in the portal.
+   */
+  getAppConfig(): AppConfigClaims {
+    const token = this.clientConfig.getToken?.() ?? this.clientConfig.token
+    return readAppConfigClaims(token)
+  }
+
+  /**
    * @param options `signal` to cancel, `timeoutMs` per attempt, `retry: false`
    *   to disable the retry loop. Every failure throws LocationServiceException.
    */
@@ -36,10 +57,14 @@ export class GeoPlacesClient {
   ): Promise<TOutput> {
     const cmd = command as unknown as GeoPlacesCommand
     const endpoint = resolveEndpoint(cmd)
-    const input = roundPositionFields(cmd.input)
 
     // Prefer the getToken callback (live ref) over a static token string.
     const token = this.clientConfig.getToken?.() ?? this.clientConfig.token
+
+    // Resolve the token BEFORE rounding: the precision this application is
+    // entitled to is a claim on it (api#65). Absent claim -> the 3 dp floor.
+    const { biasDecimals } = readAppConfigClaims(token)
+    const input = roundPositionFields(cmd.input, biasDecimals)
 
     log('Sending %s to %s', cmd.constructor?.name, endpoint)
     return requestJson<TOutput>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,10 @@ export * from '@aws/amazon-location-utilities-datatypes'
 
 // Adapters (Custom - for MapLibre integration)
 export { GeoPlaces } from './adapters/GeoPlaces'
+export type {
+  GeoPlacesDetailOptions,
+  GeoPlacesOptions,
+} from './adapters/GeoPlaces'
 
 // Maps utilities
 export { createTransformRequest } from './maps/createTransformRequest'
@@ -40,5 +44,6 @@ export { transformRequest } from './maps/Utils'
 
 // Custom Types
 export type { ClientConfig, GeoPlacesCommand, MapLike } from './types'
+export type { AppConfigClaims } from './utils/tokenClaims'
 
 // Server-only utilities are available via '@chaosity/location-client/server'

--- a/src/server/LocationServiceConnector.ts
+++ b/src/server/LocationServiceConnector.ts
@@ -5,6 +5,8 @@ import type { RequestOptions } from '../transport/http'
 import { requestJson } from '../transport/http'
 import type { GeoPlacesCommand } from '../types'
 import { roundPositionFields } from '../utils/roundPosition'
+import type { AppConfigClaims } from '../utils/tokenClaims'
+import { readAppConfigClaims } from '../utils/tokenClaims'
 import type { ServerClientConfig } from './getClientConfig'
 import { getClientConfig } from './getClientConfig'
 
@@ -49,23 +51,40 @@ export class LocationServiceConnector {
     this.origin = config?.origin
   }
 
+  /** One place that knows how a token is obtained, so nothing can drift. */
+  private async resolveToken(): Promise<string | undefined> {
+    const config = await this.configPromise
+    if ('getToken' in config && typeof config.getToken === 'function') {
+      const result = await config.getToken()
+      if (!result) return undefined
+      return typeof result === 'string' ? result : result.token
+    }
+    return (config as ConnectorConfig).token
+  }
+
+  /**
+   * This application's own configuration, as carried on the access token
+   * (api#65) — bias precision, and the countries it is scoped to.
+   *
+   * Provided so an application can SHOW its own settings: populate a country
+   * selector with the markets it actually serves, label a settings screen, and
+   * so on. Being a few minutes stale is cosmetic for that.
+   *
+   * It is not an entitlement check. See AppConfigClaims for why acting on
+   * `countries` client-side makes requests fail that would otherwise succeed.
+   *
+   * Returns `{}` when the token carries no application config, which is the
+   * case until one is configured in the portal.
+   */
+  async getAppConfig(): Promise<AppConfigClaims> {
+    return readAppConfigClaims(await this.resolveToken())
+  }
+
   async send<TInput, TOutput>(
     command: TInput,
     options?: SendOptions,
   ): Promise<TOutput> {
-    const config = await this.configPromise
-
-    let token: string | undefined
-    if ('getToken' in config && typeof config.getToken === 'function') {
-      const result = await config.getToken()
-      token = result
-        ? typeof result === 'string'
-          ? result
-          : result.token
-        : undefined
-    } else {
-      token = (config as ConnectorConfig).token
-    }
+    const token = await this.resolveToken()
 
     if (!token) {
       throw new LocationServiceException({
@@ -78,7 +97,13 @@ export class LocationServiceConnector {
 
     const cmd = command as unknown as GeoPlacesCommand
     const endpoint = resolveEndpoint(cmd)
-    const input = roundPositionFields(cmd.input)
+
+    // The token is already resolved above, so the precision this application
+    // is entitled to is available before the request is shaped (api#65).
+    // Absent claim -> the 3 dp floor, which is what every application gets
+    // until one is configured otherwise.
+    const { biasDecimals } = readAppConfigClaims(token)
+    const input = roundPositionFields(cmd.input, biasDecimals)
 
     // Caller headers first so the system ones below cannot be overridden, but an
     // explicit per-call Origin still beats the connector-wide default.
@@ -91,7 +116,7 @@ export class LocationServiceConnector {
 
     log('Sending %s request to %s', cmd.constructor?.name, endpoint)
     return requestJson<TOutput>(
-      `${config.apiUrl}${endpoint}`,
+      `${(await this.configPromise).apiUrl}${endpoint}`,
       { method: 'POST', headers, body: JSON.stringify(input) },
       options,
     )

--- a/src/utils/roundPosition.ts
+++ b/src/utils/roundPosition.ts
@@ -1,16 +1,74 @@
 /**
- * Round coordinate arrays in command inputs for better API cache hits.
+ * Round coordinate arrays in command inputs so nearby callers share a server
+ * cache entry.
  *
- * BiasPosition is rounded to 2 decimal places (~1.1 km precision) —
- * sufficient for spatial biasing while maximizing cache reuse across
- * nearby users.
+ * `BiasPosition` is a hint about where to look, so collapsing it onto a grid
+ * lets two users in the same area reuse one upstream answer. `QueryPosition`
+ * is not a hint — reverse-geocode resolves an exact point a user clicked or a
+ * device reported, and rounding it returns a neighbour's address. It is left
+ * alone (RFC-0001 §2).
  *
- * QueryPosition (reverse geocode) keeps full precision since it
- * represents an exact point the user clicked or their device reported.
+ * WHY THE DEFAULT MOVED FROM 2 dp TO 3 dp
+ *
+ * 2 dp is a ~1.1 km grid, and that is not a coarser answer — it is a wrong
+ * one. Measured against Amazon Location directly, `QueryText: "cafe"` from
+ * Sydney CBD returns a completely different set of places when the bias moves
+ * 111 m:
+ *
+ *   base      -> Crepe de Paris | Deli Ziosa | CBD Patisserie
+ *   +111 m    -> Cafe Chocolat  | Paradiso Cafe | Incanto Coffee
+ *
+ * So two users a kilometre apart both received whichever places were nearest
+ * the FIRST of them, with nothing in the response saying so. The server moved
+ * to 3 dp in api#21 — but this library rounds BEFORE sending, on both the
+ * browser and server paths, so the precision was already gone by the time the
+ * request arrived and that fix never reached anyone using the SDK. This is
+ * what makes it reach them.
+ *
+ * The cost is hit rate: cells shrink 100x in area. RFC-0001 §5 expected only
+ * "single-digit to low-double-digit percent" in mixed traffic, so there was
+ * little to protect, and a miss costs one upstream call while a wrong answer
+ * costs trust.
  */
 
-const BIAS_DECIMALS = 2 // ~1.1 km grid
-const BIAS_FACTOR = 10 ** BIAS_DECIMALS
+/** The server's floor (api#65). A request for less is clamped up to it. */
+export const DEFAULT_BIAS_DECIMALS = 3
+
+/**
+ * The band the server enforces (api#65). Mirrored here so the value this
+ * library rounds to is the value the server will actually key its cache by —
+ * rounding to something outside the band just means being wrong about what
+ * was sent.
+ *
+ * The floor is correctness: below 3 dp the nearest places are not the ones
+ * returned. The ceiling is cost: cells shrink 100x in area per decimal, so
+ * finer precision collapses the cache hit rate and every miss is a billable
+ * upstream call.
+ */
+export const MIN_BIAS_DECIMALS = 3
+export const MAX_BIAS_DECIMALS = 5
+
+/**
+ * Clamp a requested precision into the allowed band.
+ *
+ * Anything absent or malformed becomes the default rather than throwing: this
+ * runs on every request, and a surprising token claim must not break geocoding
+ * for an application that is otherwise working.
+ */
+export function clampBiasDecimals(requested?: unknown): number {
+  const n = Number(requested)
+  if (
+    (typeof requested !== 'number' &&
+      !(typeof requested === 'string' && requested.trim() !== '')) ||
+    !Number.isFinite(n)
+  ) {
+    return DEFAULT_BIAS_DECIMALS
+  }
+  const floored = Math.floor(n)
+  if (floored < MIN_BIAS_DECIMALS) return MIN_BIAS_DECIMALS
+  if (floored > MAX_BIAS_DECIMALS) return MAX_BIAS_DECIMALS
+  return floored
+}
 
 /** Known position field names and whether they should be rounded */
 const POSITION_FIELDS: Record<string, boolean> = {
@@ -18,27 +76,39 @@ const POSITION_FIELDS: Record<string, boolean> = {
   QueryPosition: false, // reverse geocode — keep full precision
 }
 
-function roundCoord(value: number): number {
-  return Math.round(value * BIAS_FACTOR) / BIAS_FACTOR
+function roundCoord(value: number, decimals: number): number {
+  const factor = 10 ** decimals
+  return Math.round(value * factor) / factor
 }
 
 /**
  * Shallow-clone the input and round position arrays that benefit from caching.
  * Returns the original object if no position fields are present.
+ *
+ * @param input      the command input
+ * @param decimals   precision for this application; defaults to the floor.
+ *                   Comes from the `biasDecimals` JWT claim where the token
+ *                   carries one (api#65) — an application entitled to finer
+ *                   bias gets it without the caller configuring anything.
  */
-export function roundPositionFields<T extends object>(input: T): T {
+export function roundPositionFields<T extends object>(
+  input: T,
+  decimals: number = DEFAULT_BIAS_DECIMALS,
+): T {
   if (!input || typeof input !== 'object') return input
 
-  let modified = false
-  const result = { ...input } as Record<string, unknown>
+  const dp = clampBiasDecimals(decimals)
+  let cloned: Record<string, unknown> | null = null
 
   for (const [field, shouldRound] of Object.entries(POSITION_FIELDS)) {
-    const value = result[field]
-    if (!shouldRound || !Array.isArray(value) || value.length < 2) continue
-
-    result[field] = value.map(roundCoord)
-    modified = true
+    if (!shouldRound) continue
+    const value = (input as Record<string, unknown>)[field]
+    if (!Array.isArray(value)) continue
+    if (!cloned) cloned = { ...(input as Record<string, unknown>) }
+    cloned[field] = value.map((v) =>
+      typeof v === 'number' && Number.isFinite(v) ? roundCoord(v, dp) : v,
+    )
   }
 
-  return modified ? (result as T) : input
+  return (cloned as T) ?? input
 }

--- a/src/utils/tokenClaims.ts
+++ b/src/utils/tokenClaims.ts
@@ -1,0 +1,96 @@
+/**
+ * Read advisory application config out of the access token (api#65).
+ *
+ * The API puts an application's own settings — `biasDecimals`, `countries` —
+ * into the JWT alongside `allowedDomain` and `allowedResources`, so this
+ * library can stop hard-coding values it has no other way of knowing.
+ *
+ * DELIBERATELY UNVERIFIED, and that is safe. This library has no signing key
+ * and does not need one: every claim here is re-read from the application row
+ * by the API on each request, and the API's answer is the one that counts. A
+ * forged token would fail at the authorizer long before any of this mattered.
+ * What is read here only decides how the request is SHAPED — a hint, never a
+ * permission.
+ *
+ * A JWT is signed, not encrypted, so the payload is plain base64url. Nothing
+ * secret is in it; these are the caller's own settings.
+ */
+
+export interface AppConfigClaims {
+  /**
+   * Bias precision this application is entitled to.
+   *
+   * Safe to act on: it only changes how a coordinate is rounded before
+   * sending, and the server re-rounds to its own configured value anyway. A
+   * stale value here costs precision, never correctness.
+   */
+  biasDecimals?: number
+  /**
+   * Countries this application may search, ISO 3166-1 alpha-2.
+   *
+   * READ THIS, DO NOT ACT ON IT. It is here to be displayed — a country
+   * selector, a settings screen, a "this application serves AU and NZ" label.
+   *
+   * Do not inject it into requests and do not reject requests with it. The
+   * token is a snapshot up to fifteen minutes old; the API reads the scope
+   * fresh from the application row on every request. Acting on a stale value
+   * makes things WORSE, in both directions:
+   *
+   *   app is now scoped to NZ, token still says AU
+   *     send nothing         -> API injects [NZ]  -> 200
+   *     inject stale [AU]    -> outside scope     -> 400
+   *
+   * So a request that would have succeeded fails instead. Rejecting locally
+   * has the mirror-image bug: refusing something the API would now allow.
+   * Sending nothing and letting the API scope the request is always correct.
+   */
+  countries?: string[]
+}
+
+/**
+ * Decode a JWT payload without verifying it.
+ *
+ * Returns `{}` for anything unparseable. This runs on every request, so a
+ * surprising token must degrade to "no claims" rather than break geocoding
+ * for an application that is otherwise working.
+ */
+export function readAppConfigClaims(token?: string | null): AppConfigClaims {
+  if (typeof token !== 'string') return {}
+
+  const parts = token.split('.')
+  if (parts.length !== 3) return {}
+
+  try {
+    // base64url -> base64: JWT omits padding and swaps two characters.
+    const b64 = parts[1]!.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), '=')
+    // `atob` exists in browsers and in Node 16+, so one path serves both.
+    const json = decodeURIComponent(
+      Array.from(
+        atob(padded),
+        (c) => `%${c.charCodeAt(0).toString(16).padStart(2, '0')}`,
+      ).join(''),
+    )
+    const payload = JSON.parse(json) as Record<string, unknown>
+
+    const claims: AppConfigClaims = {}
+    if (typeof payload.biasDecimals === 'number') {
+      claims.biasDecimals = payload.biasDecimals
+    } else if (
+      typeof payload.biasDecimals === 'string' &&
+      payload.biasDecimals.trim() !== ''
+    ) {
+      const n = Number(payload.biasDecimals)
+      if (Number.isFinite(n)) claims.biasDecimals = n
+    }
+    if (Array.isArray(payload.countries)) {
+      const list = payload.countries.filter(
+        (c): c is string => typeof c === 'string',
+      )
+      if (list.length) claims.countries = list
+    }
+    return claims
+  } catch {
+    return {}
+  }
+}

--- a/test/geoplaces-adapter.test.ts
+++ b/test/geoplaces-adapter.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { GeoPlaces } from '../src/adapters/GeoPlaces'
+import type { GeoPlacesClient } from '../src/client/GeoPlacesClient'
+
+/**
+ * What the geocoder adapter asks Amazon Location for, and what that costs
+ * (#3 / T19, finding A-9).
+ *
+ * Buckets measured directly against Amazon Location on 2026-08-25 by sending
+ * each variant and reading `PricingBucket` back:
+ *
+ *   Suggest with [Core]          -> Core      $0.50/1k
+ *   Suggest with nothing         -> Label     $0.20/1k
+ *   GetPlace all four features   -> Advanced  $1.50/1k
+ *   GetPlace none                -> Core      $0.50/1k
+ *   GetPlace SecondaryAddresses  -> Core      $0.50/1k
+ *   GetPlace Access|Contact|TimeZone (any) -> Advanced $1.50/1k
+ */
+
+const sent: { name: string; input: Record<string, unknown> }[] = []
+
+const fakeClient = {
+  send: async (cmd: { constructor: { name: string }; input: unknown }) => {
+    sent.push({
+      name: cmd.constructor.name,
+      input: cmd.input as Record<string, unknown>,
+    })
+    return { ResultItems: [], Title: '', Address: {}, Position: [0, 0] }
+  },
+} as unknown as GeoPlacesClient
+
+const fakeMap = { getCenter: () => ({ lng: 151.209, lat: -33.869 }) }
+
+const adapter = (options?: ConstructorParameters<typeof GeoPlaces>[2]) =>
+  new GeoPlaces(fakeClient, fakeMap as never, options)
+
+const lastInput = () => sent[sent.length - 1]!.input
+
+describe('Suggest lands in the Label bucket', () => {
+  it('sends no AdditionalFeatures at all', async () => {
+    // It used to send [Core] on every keystroke — $0.50/1k — while reading
+    // only Title and Place.PlaceId from the response. Core's sole addition to
+    // a Suggest result is `Highlights`, which this adapter never touches.
+    sent.length = 0
+    await adapter().getSuggestions({ query: 'martin pl' } as never)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.name).toBe('SuggestCommand')
+    expect(lastInput()).not.toHaveProperty('AdditionalFeatures')
+  })
+
+  it('still sends the bias position and query', async () => {
+    sent.length = 0
+    await adapter().getSuggestions({ query: 'martin pl' } as never)
+    expect(lastInput().QueryText).toBe('martin pl')
+    expect(lastInput().BiasPosition).toBeDefined()
+  })
+
+  it('still honours a caller country filter', async () => {
+    sent.length = 0
+    await adapter().getSuggestions({
+      query: 'queen st',
+      countries: 'NZ',
+    } as never)
+    expect(lastInput().Filter).toEqual({ IncludeCountries: ['NZ'] })
+  })
+})
+
+describe('GetPlace detail is opt-in, so the default stays in Core', () => {
+  it('sends no AdditionalFeatures when nothing is requested', async () => {
+    // The default used to be Access + SecondaryAddresses + Contact + TimeZone,
+    // which is the Advanced bucket at 3x the price, on every detail lookup.
+    sent.length = 0
+    await adapter().searchByPlaceId({ query: 'place-1' } as never)
+
+    expect(sent[0]!.name).toBe('GetPlaceCommand')
+    expect(lastInput()).not.toHaveProperty('AdditionalFeatures')
+  })
+
+  it('sends only what the caller opted into', async () => {
+    sent.length = 0
+    await adapter({ details: { timeZone: true } }).searchByPlaceId({
+      query: 'place-1',
+    } as never)
+    expect(lastInput().AdditionalFeatures).toEqual(['TimeZone'])
+  })
+
+  it('keeps the address form working: SecondaryAddresses alone stays Core', async () => {
+    // The one feature of the four that does NOT move the bucket, so enabling
+    // it is free. This is the case the address form needs.
+    sent.length = 0
+    await adapter({ details: { secondaryAddresses: true } }).searchByPlaceId({
+      query: 'place-1',
+    } as never)
+    expect(lastInput().AdditionalFeatures).toEqual(['SecondaryAddresses'])
+  })
+
+  it('can still request everything, for callers that want it', async () => {
+    sent.length = 0
+    await adapter({
+      details: {
+        access: true,
+        secondaryAddresses: true,
+        contact: true,
+        timeZone: true,
+      },
+    }).searchByPlaceId({ query: 'place-1' } as never)
+
+    expect(lastInput().AdditionalFeatures).toEqual([
+      'Access',
+      'SecondaryAddresses',
+      'Contact',
+      'TimeZone',
+    ])
+  })
+
+  it('omits the field rather than sending an empty array', async () => {
+    // An empty array is still a field on the request; the point is to send
+    // nothing at all.
+    sent.length = 0
+    await adapter({ details: {} }).searchByPlaceId({
+      query: 'place-1',
+    } as never)
+    expect(lastInput().AdditionalFeatures).toBeUndefined()
+  })
+})

--- a/test/pricing-and-bias.test.ts
+++ b/test/pricing-and-bias.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clampBiasDecimals,
+  DEFAULT_BIAS_DECIMALS,
+  roundPositionFields,
+} from '../src/utils/roundPosition'
+import { readAppConfigClaims } from '../src/utils/tokenClaims'
+
+/**
+ * The two things this library was silently costing people (#3 / T19).
+ *
+ * It asked Amazon Location for data it then threw away — putting every
+ * keystroke in a dearer pricing bucket — and it flattened the bias position
+ * onto a 1.1 km grid before sending, which does not return coarser results but
+ * different, wrong ones.
+ */
+
+/** A token whose payload is exactly these claims; signature is never checked. */
+const tokenWith = (claims: Record<string, unknown>): string => {
+  const b64 = (o: unknown) =>
+    btoa(JSON.stringify(o))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+  return `${b64({ alg: 'HS256' })}.${b64(claims)}.not-a-real-signature`
+}
+
+const SYDNEY = { QueryText: 'cafe', BiasPosition: [151.20931, -33.86882] }
+
+describe('bias precision defaults to the correct value, not the cheapest', () => {
+  it('rounds to 3 dp by default, not the 2 dp this library used to send', () => {
+    // 2 dp is ~1.1 km. Measured against Amazon Location, the same "cafe" query
+    // biased 111 m apart returns a completely different set of places — so the
+    // old default did not return coarser results, it returned wrong ones.
+    expect(DEFAULT_BIAS_DECIMALS).toBe(3)
+    const out = roundPositionFields(SYDNEY)
+    expect(out.BiasPosition).toEqual([151.209, -33.869])
+  })
+
+  it('never rounds QueryPosition, whatever the precision', () => {
+    // Reverse-geocode resolves an exact point a user clicked. Rounding it
+    // returns a neighbour's address (RFC-0001 §2).
+    const input = { QueryPosition: [151.20931, -33.86882] }
+    for (const dp of [3, 4, 5]) {
+      expect(roundPositionFields(input, dp).QueryPosition).toEqual([
+        151.20931, -33.86882,
+      ])
+    }
+  })
+
+  it('honours a finer entitlement', () => {
+    expect(roundPositionFields(SYDNEY, 5).BiasPosition).toEqual([
+      151.20931, -33.86882,
+    ])
+  })
+
+  it('does not mutate the caller input', () => {
+    const original = { BiasPosition: [151.20931, -33.86882] }
+    roundPositionFields(original, 3)
+    expect(original.BiasPosition).toEqual([151.20931, -33.86882])
+  })
+
+  it('leaves inputs with no position field untouched', () => {
+    const input = { QueryText: 'cafe' }
+    expect(roundPositionFields(input)).toBe(input)
+  })
+})
+
+describe('the precision band mirrors the server (api#65)', () => {
+  it.each([[2], [1], [0], [-3]])('clamps %i dp up to the 3 dp floor', (dp) => {
+    expect(clampBiasDecimals(dp)).toBe(3)
+  })
+
+  it('caps at 5 dp', () => {
+    // Finer precision collapses the cache hit rate, and every miss is a
+    // billable upstream call.
+    expect(clampBiasDecimals(8)).toBe(5)
+    expect(clampBiasDecimals(99)).toBe(5)
+  })
+
+  it('allows the band between', () => {
+    expect(clampBiasDecimals(3)).toBe(3)
+    expect(clampBiasDecimals(4)).toBe(4)
+    expect(clampBiasDecimals(5)).toBe(5)
+  })
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty string', ''],
+    ['nonsense', 'wide'],
+    ['an object', {}],
+    ['an array', []],
+    ['NaN', NaN],
+  ])('falls back to the default for %s', (_label, value) => {
+    // `Number(null)`, `Number('')` and `Number([])` are all 0 — finite, and so
+    // accepted by the obvious check. That would silently mean "precision 0".
+    expect(clampBiasDecimals(value)).toBe(DEFAULT_BIAS_DECIMALS)
+  })
+
+  it('accepts a numeric string', () => {
+    expect(clampBiasDecimals('4')).toBe(4)
+  })
+})
+
+describe('reading app config off the token', () => {
+  it('reads biasDecimals and countries', () => {
+    const token = tokenWith({ biasDecimals: 5, countries: ['AU', 'NZ'] })
+    expect(readAppConfigClaims(token)).toEqual({
+      biasDecimals: 5,
+      countries: ['AU', 'NZ'],
+    })
+  })
+
+  it('returns nothing for a token carrying no app config', () => {
+    // The API omits these claims entirely when the application has none
+    // configured, which is every application today.
+    const token = tokenWith({ client_id: 'abc', allowedDomain: 'example.com' })
+    expect(readAppConfigClaims(token)).toEqual({})
+  })
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty', ''],
+    ['not a JWT', 'hello'],
+    ['wrong segment count', 'a.b'],
+    ['undecodable payload', 'aaa.!!!not-base64!!!.ccc'],
+  ])('degrades to no claims for %s rather than throwing', (_l, token) => {
+    // This runs on every request. A surprising token must not break geocoding
+    // for an application that is otherwise working.
+    expect(() => readAppConfigClaims(token as string)).not.toThrow()
+    expect(readAppConfigClaims(token as string)).toEqual({})
+  })
+
+  it('ignores claim values of the wrong type', () => {
+    const token = tokenWith({ biasDecimals: {}, countries: 'AU' })
+    expect(readAppConfigClaims(token)).toEqual({})
+  })
+
+  it('feeds straight into rounding, so an entitled app gets its precision', () => {
+    const { biasDecimals } = readAppConfigClaims(tokenWith({ biasDecimals: 5 }))
+    expect(roundPositionFields(SYDNEY, biasDecimals).BiasPosition).toEqual([
+      151.20931, -33.86882,
+    ])
+  })
+
+  it('an unentitled app lands on the floor, not the old 2 dp', () => {
+    const { biasDecimals } = readAppConfigClaims(tokenWith({ client_id: 'x' }))
+    expect(roundPositionFields(SYDNEY, biasDecimals).BiasPosition).toEqual([
+      151.209, -33.869,
+    ])
+  })
+})
+
+describe('the countries claim is exposed, never acted on', () => {
+  it('is readable, so an application can show the markets it serves', () => {
+    const token = tokenWith({ countries: ['AU', 'NZ'] })
+    expect(readAppConfigClaims(token).countries).toEqual(['AU', 'NZ'])
+  })
+
+  it('is surfaced by the browser client', async () => {
+    const { GeoPlacesClient } = await import('../src/client/GeoPlacesClient')
+    const client = new GeoPlacesClient({
+      apiUrl: 'https://example.invalid',
+      token: tokenWith({ countries: ['AU'], biasDecimals: 4 }),
+    } as never)
+
+    expect(client.getAppConfig()).toEqual({
+      countries: ['AU'],
+      biasDecimals: 4,
+    })
+  })
+
+  it('is empty when the application has no config, which is every app today', async () => {
+    const { GeoPlacesClient } = await import('../src/client/GeoPlacesClient')
+    const client = new GeoPlacesClient({
+      apiUrl: 'https://example.invalid',
+      token: tokenWith({ client_id: 'abc' }),
+    } as never)
+
+    expect(client.getAppConfig()).toEqual({})
+  })
+
+  it('does NOT inject countries into a request', async () => {
+    // The reason, measured against the API: if the scope changed in the portal
+    // and the token is stale, injecting turns a request that would have
+    // SUCCEEDED into a 400.
+    //
+    //   app now scoped to NZ, token still says AU
+    //     send nothing      -> API injects [NZ] -> 200
+    //     inject stale [AU] -> outside scope    -> 400
+    //
+    // The API always has fresh data; the token never does. Sending nothing is
+    // strictly better than any client-side guess.
+    const sent: Record<string, unknown>[] = []
+    const fetchSpy = async (_url: string, init: { body: string }) => {
+      sent.push(JSON.parse(init.body))
+      return new Response(JSON.stringify({ ResultItems: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    const original = globalThis.fetch
+    globalThis.fetch = fetchSpy as never
+    try {
+      const { GeoPlacesClient } = await import('../src/client/GeoPlacesClient')
+      const client = new GeoPlacesClient({
+        apiUrl: 'https://example.invalid',
+        token: tokenWith({ countries: ['AU'] }),
+      } as never)
+      const { SearchTextCommand } = await import('@aws-sdk/client-geo-places')
+      await client.send(new SearchTextCommand({ QueryText: 'cafe' }) as never)
+    } finally {
+      globalThis.fetch = original
+    }
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).not.toHaveProperty('Filter')
+  })
+})


### PR DESCRIPTION
Two things this library was costing people silently, plus the bug that made api#21's fix invisible to everyone using the SDK.

**Every pricing bucket below was measured against Amazon Location on 2026-08-25** by sending the variant and reading `PricingBucket` back. None of it is inferred.

## Suggest now lands in the Label bucket

It sent `AdditionalFeatures: [Core]` on every keystroke while reading only `Title` and `Place.PlaceId`. Core's sole addition to a Suggest result is `Highlights`, which this adapter never touches:

```
with [Core] -> bucket Core   keys: Title, SuggestResultItemType, Place, Highlights
without     -> bucket Label  keys: Title, SuggestResultItemType, Place
```

Same two fields, **$0.20/1k instead of $0.50**. Suggest fires per keystroke, so it is the highest-volume call the library makes.

## GetPlace detail is opt-in

`searchByPlaceId` always requested Access + SecondaryAddresses + Contact + TimeZone — the **Advanced** bucket at $1.50/1k on every detail lookup. Measured per feature:

| Requested | Bucket | Cost |
|---|---|---|
| none | Core | $0.50/1k |
| `SecondaryAddresses` | **Core** | $0.50/1k |
| `Access` | Advanced | $1.50/1k |
| `TimeZone` | Advanced | $1.50/1k |
| `Contact` | Advanced | $1.50/1k |

`SecondaryAddresses` is the only one of the four that does not move the bucket, so **the address form's case stays in Core**. `Contact` is worth avoiding by default for a second reason: on a street address it costs Advanced and returns **no contact field at all** — only POIs carry one.

```ts
new GeoPlaces(client, map, { details: { secondaryAddresses: true } })
```

## Bias precision: 2 dp → 3 dp

**This is a bug fix, not a tuning change.** 2 dp is a ~1.1 km grid, and api#21 measured that the same `"cafe"` query biased 111 m apart returns a completely different set of places:

```
base    -> Crepe de Paris | Deli Ziosa   | CBD Patisserie
+111 m  -> Cafe Chocolat  | Paradiso Cafe | Incanto Coffee
```

The API moved to 3 dp in api#21 — but this library rounds **before sending**, on both `GeoPlacesClient.send` and `LocationServiceConnector.send`, so the precision was already gone on arrival and that fix never reached anyone using the SDK.

Precision now comes from the `biasDecimals` JWT claim (api#65) where the token carries one, clamped to the same 3–5 band the server enforces. **No application is configured yet**, so the claim is absent everywhere and the *default* is what actually fixes this for people today.

## `countries` is exposed, and deliberately not acted on

Both clients gain `getAppConfig()` → `{ biasDecimals?, countries? }`, so an application can show the markets it serves — a country selector, a settings label.

It is **not** used to shape requests, and that is the interesting decision. The token is a snapshot; the API reads the scope fresh from the application row on every request. Measured against the API:

```
app now scoped to NZ, token still says AU
  send nothing      -> API injects [NZ] -> 200
  inject stale [AU] -> outside scope    -> 400
```

Injecting turns a request that would have **succeeded** into a failure, and rejecting locally has the mirror-image bug. A test asserts the negative directly: a client holding a `countries` claim sends **no `Filter` at all**.

The two claims therefore get opposite treatment, documented on `AppConfigClaims` so nobody later "improves" it:

| Claim | Acted on? | Why |
|---|---|---|
| `biasDecimals` | yes | only changes rounding; the server re-rounds to its own value. Stale costs precision, never correctness |
| `countries` | no | acting on a stale value causes a failure that would not otherwise happen |

## Verification

Build, **62 tests**, `tsc --noEmit`, Prettier — all clean. The claim reader is deliberately unverified (no signing key here, and none needed: the API re-reads every value from the row; this only shapes a request, it never grants anything).

## For the reviewer

- **One change is not purely additive.** `LocationServiceConnector` resolved its token inline inside `send()`; it is now `resolveToken()`, so `send()` and `getAppConfig()` cannot drift. `send()` re-awaits the already-resolved `configPromise` for `apiUrl`.
- **`package-lock.json` is untouched.**
- The pre-commit lint reports one pre-existing warning in `createTransformRequest.ts` (`resourceType` unused) — not from this change; 0 errors.

## Release implications

**This is a minor, not a patch.** `searchByPlaceId` silently stops returning `AccessPoints`, `TimeZone` and contact fields until callers opt in — a behaviour break, and on `0.x` a caret range is the only protection consumers get.

`0.2.1 → 0.3.0`, and it cascades: `client-react`, `address-form` and eight samples carry `^0.2.x` ranges that cannot cross the minor. That chain is `/publish-lib`'s dependency order and belongs to a separate run.

Refs #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
