### PR TITLE
Release v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Releases `@chaosity/location-client` **0.2.1 → 0.3.0**.

## Why minor, not patch

**A behaviour break, and on `0.x` the caret range is the only protection consumers get.** `searchByPlaceId` silently stops returning `AccessPoints`, `TimeZone` and contact fields until the caller opts in:

```ts
new GeoPlaces(client, map, { details: { access: true, timeZone: true } })
```

`^0.2.x` will not resolve `0.3.0`, which is exactly what should happen to anyone relying on the old response shape. A patch would have upgraded them silently into missing data.

## What is in it

One commit since `v0.2.1` — [#15](https://github.com/chaosity-io/location-service-client/pull/15), closing client#3. Pricing buckets measured against Amazon Location, not inferred:

| Change | Before | After |
|---|---|---|
| Suggest drops `[Core]` | Core $0.50/1k | **Label $0.20/1k** |
| GetPlace detail opt-in | Advanced $1.50/1k | **Core $0.50/1k** |
| Bias default | 2 dp (~1.1 km) | **3 dp (~111 m)** |

Suggest fires per keystroke, so it is the highest-volume call the library makes — and `[Core]`'s only addition to a Suggest result is `Highlights`, which the adapter never reads.

**The bias change is a bug fix.** api#21 moved the API to 3 dp after measuring that POI ranking turns over completely at 111 m, but this library rounds *before sending* on both the browser and server paths — so that fix never reached anyone using the SDK. This release is what delivers it.

Also new: `getAppConfig()` on both clients, exposing the `biasDecimals` and `countries` claims (api#65) for display. `countries` is deliberately **not** acted on — the token is a snapshot, and injecting a stale scope turns a request that would have succeeded into a 400.

## New public API

```
GeoPlacesOptions, GeoPlacesDetailOptions, AppConfigClaims
GeoPlacesClient#getAppConfig()
LocationServiceConnector#getAppConfig()
```

## Verification (§1 gate, on a clean `main`)

```
clean tree     yes
on main        yes, already up to date
npm ci         no lockfile drift
lint           0 errors (1 pre-existing warning: resourceType unused)
test           3 files, 62 tests
build          tsc clean
```

Tag `v0.3.0` is SSH-signed and verified: `Good "git" signature for mj@chaosity.io`.

## Dependency order

This is the **base** of the chain — no `@chaosity` dependencies, nothing upstream to check.

**Publishing this strands the dependents until their ranges move**, because `^0.2.x` cannot cross the minor:

| | Current range |
|---|---|
| `location-service-client-react` | `^0.2.1` |
| `nextjs-address-finder-full` | `^0.2.1` |
| 7 other samples | `^0.1.14` — already two minors behind |

Those bumps are separate work and cannot happen until this is actually on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
