### PR TITLE
Export the map parameter values, and fix two that were wrong

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,37 @@ export {
 export type { PoiCategory } from './maps/mapPoi'
 export { buildMapStyleUrl, fetchMapStyle } from './maps/mapStyle'
 export type { MapStyleOptions } from './maps/mapStyle'
+
+// Accepted values for every map parameter, as VALUES so a picker can be built
+// from them, plus the matching types. Case sensitive — see mapEnums.ts.
+export {
+  BUILDINGS,
+  COLOR_SCHEMES,
+  CONTOUR_DENSITIES,
+  LABEL_SIZES,
+  MAP_FEATURE_MODES,
+  MAP_STYLES,
+  SCALE_BAR_UNITS,
+  SPRITE_VARIANTS,
+  STATIC_MAP_STYLES,
+  TERRAINS,
+  TRAFFIC_MODES,
+  TRAVEL_MODES,
+} from './maps/mapEnums'
+export type {
+  Buildings,
+  ColorScheme,
+  ContourDensity,
+  LabelSize,
+  MapFeatureMode,
+  MapStyle,
+  ScaleBarUnit,
+  SpriteVariant,
+  StaticMapStyle,
+  Terrain,
+  TrafficMode,
+  TravelMode,
+} from './maps/mapEnums'
 export { transformRequest } from './maps/Utils'
 
 // Custom Types

--- a/src/maps/mapEnums.ts
+++ b/src/maps/mapEnums.ts
@@ -1,0 +1,124 @@
+/**
+ * The values Amazon Location accepts for each map parameter.
+ *
+ * WHY THESE ARE EXPORTED AS VALUES, NOT JUST TYPES
+ *
+ * A type union gives you compile-time safety and nothing to iterate. Every
+ * consumer that renders a style picker then re-types the same list by hand into
+ * a `<select>`, and those copies drift the moment AWS adds a style. Exporting
+ * the arrays means a dropdown is `MAP_STYLES.map(...)` and cannot disagree with
+ * the type beside it.
+ *
+ * THESE ARE CASE SENSITIVE
+ *
+ * AWS documents them so, and since location-service-api#89 the API enforces it
+ * rather than forwarding a wrong-cased value for Amazon to reject with an
+ * unhelpful 404. `'light'` is not `'Light'`:
+ *
+ *   GET /maps/Standard/descriptor?colorScheme=light
+ *   400  "'colorScheme' is case sensitive — use 'Light', not 'light'"
+ *
+ * So take the values from here rather than typing them, and the case is right
+ * by construction.
+ *
+ * MEMBERSHIP IS NOT THE WHOLE STORY
+ *
+ * A value being in one of these lists does not mean it is legal in every
+ * COMBINATION. `Traffic: 'All'` is valid, and `Style: 'Satellite'` is valid,
+ * but together they are not:
+ *
+ *   400  "Traffic is not supported for style."
+ *
+ * Amazon owns those rules and answers them per request; the API forwards that
+ * message verbatim. Do not try to encode combination rules here — they change
+ * without an SDK release.
+ *
+ * KEEPING THESE HONEST
+ *
+ * The API derives its copy from the AWS SDK's own `enums.d.ts` via
+ * `npm run generate:maps-enums`, so that side cannot drift. This file is the
+ * client-side mirror and every value below was additionally confirmed against
+ * the live geo-maps API on 2026-08-26. If the API starts rejecting something
+ * listed here, its generated list is the authority.
+ */
+
+/** Map styles for the style descriptor. */
+export const MAP_STYLES = [
+  'Hybrid',
+  'Monochrome',
+  'Satellite',
+  'Standard',
+] as const
+export type MapStyle = (typeof MAP_STYLES)[number]
+
+/**
+ * Styles the STATIC map accepts — deliberately narrower than `MAP_STYLES`.
+ *
+ * `/maps/static/*` takes only Satellite and Standard. Passing Hybrid or
+ * Monochrome there is a 400, so the two lists are not interchangeable.
+ */
+export const STATIC_MAP_STYLES = ['Satellite', 'Standard'] as const
+export type StaticMapStyle = (typeof STATIC_MAP_STYLES)[number]
+
+/** Light or dark cartography. Not applicable to the raster styles. */
+export const COLOR_SCHEMES = ['Dark', 'Light'] as const
+export type ColorScheme = (typeof COLOR_SCHEMES)[number]
+
+/** Terrain overlay. `Hillshade` is shaded relief; `Terrain3D` is elevation. */
+export const TERRAINS = ['Hillshade', 'Terrain3D'] as const
+export type Terrain = (typeof TERRAINS)[number]
+
+/** 3D building extrusions. One value today, kept a list for when that changes. */
+export const BUILDINGS = ['Buildings3D'] as const
+export type Buildings = (typeof BUILDINGS)[number]
+
+/**
+ * Elevation contour line density.
+ *
+ * All three work. An earlier version of this library documented `Medium` as
+ * "the only value currently supported by the AWS SDK", which was wrong — `High`
+ * and `Low` were both confirmed against the live API on 2026-08-26.
+ */
+export const CONTOUR_DENSITIES = ['High', 'Low', 'Medium'] as const
+export type ContourDensity = (typeof CONTOUR_DENSITIES)[number]
+
+/**
+ * Traffic overlay.
+ *
+ * `Congestion` was previously missing from this library's types, so it could
+ * not be requested from TypeScript even though the API accepts it.
+ */
+export const TRAFFIC_MODES = ['All', 'Congestion'] as const
+export type TrafficMode = (typeof TRAFFIC_MODES)[number]
+
+/** Routing overlays. Sent as a comma-separated list; each entry is checked. */
+export const TRAVEL_MODES = ['Transit', 'Truck'] as const
+export type TravelMode = (typeof TRAVEL_MODES)[number]
+
+/** Sprite sheet variant. One value today. */
+export const SPRITE_VARIANTS = ['Default'] as const
+export type SpriteVariant = (typeof SPRITE_VARIANTS)[number]
+
+/** Static map label size. */
+export const LABEL_SIZES = ['Large', 'Small'] as const
+export type LabelSize = (typeof LABEL_SIZES)[number]
+
+/** Static map scale bar units. */
+export const SCALE_BAR_UNITS = [
+  'Kilometers',
+  'KilometersMiles',
+  'Miles',
+  'MilesKilometers',
+] as const
+export type ScaleBarUnit = (typeof SCALE_BAR_UNITS)[number]
+
+/**
+ * Static map points-of-interest rendering.
+ *
+ * A MODE, not a list of categories — an easy one to get wrong, and the reason
+ * the static map route returned a confusing error before
+ * location-service-api#35. To filter POIs on an interactive map, use
+ * `setPoiVisibility` instead.
+ */
+export const MAP_FEATURE_MODES = ['Disabled', 'Enabled'] as const
+export type MapFeatureMode = (typeof MAP_FEATURE_MODES)[number]

--- a/src/maps/mapStyle.ts
+++ b/src/maps/mapStyle.ts
@@ -1,24 +1,51 @@
 import type { StyleSpecification } from 'maplibre-gl'
+import type {
+  Buildings,
+  ColorScheme,
+  ContourDensity,
+  MapStyle,
+  Terrain,
+  TrafficMode,
+  TravelMode,
+} from './mapEnums'
 
 /**
  * Options for building an AWS Location Service map style URL.
  * All parameters map directly to query parameters supported by the style descriptor endpoint.
+ *
+ * Values are CASE SENSITIVE — the API rejects a wrong-cased one with a 400 that
+ * names the right spelling. Import the arrays from `mapEnums` to build pickers
+ * rather than typing the values, and the case is right by construction.
  */
 export interface MapStyleOptions {
   /** Color scheme for the map (default: Light). Not applicable to Satellite/Hybrid styles. */
-  colorScheme?: 'Light' | 'Dark'
+  colorScheme?: ColorScheme
   /** ISO 3166-1 alpha-3 country code for political boundary perspective (e.g. 'IND', 'TUR'). */
   politicalView?: string
   /** Terrain overlay type. */
-  terrain?: 'Hillshade' | 'Terrain3D'
+  terrain?: Terrain
   /** Enable 3D building extrusions. */
-  buildings?: 'Buildings3D'
-  /** Elevation contour line density. Only 'Medium' is currently supported by the AWS SDK. */
-  contourDensity?: 'Medium'
-  /** Enable real-time traffic flow visualization. */
-  traffic?: 'All'
+  buildings?: Buildings
+  /**
+   * Elevation contour line density.
+   *
+   * All of High, Low and Medium work. This was previously typed as `'Medium'`
+   * alone, documented as "the only value currently supported by the AWS SDK",
+   * which was wrong — the other two were confirmed against the live API.
+   */
+  contourDensity?: ContourDensity
+  /**
+   * Traffic overlay.
+   *
+   * `Congestion` was previously missing here, so it could not be requested from
+   * TypeScript even though the API accepts it.
+   *
+   * Valid on its own, but NOT with every style: `Satellite` + `All` answers
+   * 400 "Traffic is not supported for style." Amazon owns that rule.
+   */
+  traffic?: TrafficMode
   /** Travel mode overlays for routing-specific features. */
-  travelModes?: Array<'Truck' | 'Transit'>
+  travelModes?: TravelMode[]
 }
 
 /**
@@ -35,7 +62,7 @@ export interface MapStyleOptions {
  */
 export function buildMapStyleUrl(
   apiUrl: string,
-  mapStyle: string,
+  mapStyle: MapStyle,
   options: MapStyleOptions = {},
 ): string {
   const params = new URLSearchParams()
@@ -77,7 +104,7 @@ export function buildMapStyleUrl(
  */
 export async function fetchMapStyle(
   apiUrl: string,
-  mapStyle: string,
+  mapStyle: MapStyle,
   getToken: () => string | undefined,
   options: MapStyleOptions & { language?: string } = {},
 ): Promise<StyleSpecification> {

--- a/test/map-enums.test.ts
+++ b/test/map-enums.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BUILDINGS,
+  COLOR_SCHEMES,
+  CONTOUR_DENSITIES,
+  LABEL_SIZES,
+  MAP_FEATURE_MODES,
+  MAP_STYLES,
+  SCALE_BAR_UNITS,
+  SPRITE_VARIANTS,
+  STATIC_MAP_STYLES,
+  TERRAINS,
+  TRAFFIC_MODES,
+  TRAVEL_MODES,
+  buildMapStyleUrl,
+} from '../src/index'
+
+/**
+ * The accepted values for every map parameter.
+ *
+ * These mirror the API's generated lists, which are derived from the AWS SDK's
+ * own `enums.d.ts`. Two sources describing one thing is a drift risk, so the
+ * values are pinned here rather than merely typed — if AWS adds a style and the
+ * API regenerates, this suite fails and says so out loud.
+ *
+ * Every value was confirmed against the live geo-maps API on 2026-08-26.
+ */
+
+describe('the accepted values, pinned', () => {
+  it.each([
+    [
+      'MAP_STYLES',
+      MAP_STYLES,
+      ['Hybrid', 'Monochrome', 'Satellite', 'Standard'],
+    ],
+    ['STATIC_MAP_STYLES', STATIC_MAP_STYLES, ['Satellite', 'Standard']],
+    ['COLOR_SCHEMES', COLOR_SCHEMES, ['Dark', 'Light']],
+    ['TERRAINS', TERRAINS, ['Hillshade', 'Terrain3D']],
+    ['BUILDINGS', BUILDINGS, ['Buildings3D']],
+    ['CONTOUR_DENSITIES', CONTOUR_DENSITIES, ['High', 'Low', 'Medium']],
+    ['TRAFFIC_MODES', TRAFFIC_MODES, ['All', 'Congestion']],
+    ['TRAVEL_MODES', TRAVEL_MODES, ['Transit', 'Truck']],
+    ['SPRITE_VARIANTS', SPRITE_VARIANTS, ['Default']],
+    ['LABEL_SIZES', LABEL_SIZES, ['Large', 'Small']],
+    [
+      'SCALE_BAR_UNITS',
+      SCALE_BAR_UNITS,
+      ['Kilometers', 'KilometersMiles', 'Miles', 'MilesKilometers'],
+    ],
+    ['MAP_FEATURE_MODES', MAP_FEATURE_MODES, ['Disabled', 'Enabled']],
+  ])('%s', (_name, actual, expected) => {
+    expect([...actual]).toEqual(expected)
+  })
+})
+
+describe('the corrections this module exists to make', () => {
+  it('offers all three contour densities, not just Medium', () => {
+    // Previously typed as `'Medium'` alone and documented as "the only value
+    // currently supported by the AWS SDK". High and Low both work.
+    expect(CONTOUR_DENSITIES).toContain('High')
+    expect(CONTOUR_DENSITIES).toContain('Low')
+  })
+
+  it('offers Congestion, which could not be requested before', () => {
+    expect(TRAFFIC_MODES).toContain('Congestion')
+  })
+
+  it('keeps the static map style list narrower than the descriptor one', () => {
+    // /maps/static/* takes only Satellite and Standard; passing Hybrid or
+    // Monochrome there is a 400. The two lists are not interchangeable.
+    expect(STATIC_MAP_STYLES.length).toBeLessThan(MAP_STYLES.length)
+    for (const s of STATIC_MAP_STYLES) expect(MAP_STYLES).toContain(s)
+    expect(MAP_STYLES).toContain('Hybrid')
+    expect(STATIC_MAP_STYLES).not.toContain('Hybrid')
+  })
+})
+
+describe('every value is spelled the way the API demands', () => {
+  it('has no value that differs from another only by case', () => {
+    // The API is case sensitive and rejects a wrong-cased value. A list holding
+    // both `Light` and `light` would make that impossible to reason about.
+    for (const list of [
+      MAP_STYLES,
+      COLOR_SCHEMES,
+      TERRAINS,
+      CONTOUR_DENSITIES,
+      TRAFFIC_MODES,
+      TRAVEL_MODES,
+    ]) {
+      const lowered = list.map((v) => v.toLowerCase())
+      expect(new Set(lowered).size).toBe(list.length)
+    }
+  })
+
+  // Each case is wrapped in its own array: it.each spreads a top-level array
+  // into the test's arguments, so a bare list would arrive as its first string.
+  it.each([
+    [MAP_STYLES],
+    [COLOR_SCHEMES],
+    [TERRAINS],
+    [CONTOUR_DENSITIES],
+    [TRAFFIC_MODES],
+    [TRAVEL_MODES],
+    [LABEL_SIZES],
+    [SCALE_BAR_UNITS],
+    [MAP_FEATURE_MODES],
+  ])('starts every value with a capital, as Amazon spells them', (list) => {
+    for (const v of list) expect(v[0]).toBe(v[0].toUpperCase())
+  })
+})
+
+describe('the values reach the URL unchanged', () => {
+  it('sends the exact spelling as query parameters', () => {
+    // The point of exporting values: what the picker offers is what is sent.
+    const url = buildMapStyleUrl('https://api.example.com', 'Standard', {
+      colorScheme: 'Dark',
+      terrain: 'Terrain3D',
+      contourDensity: 'High',
+      traffic: 'Congestion',
+      travelModes: ['Truck', 'Transit'],
+    })
+
+    expect(url).toContain('color-scheme=Dark')
+    expect(url).toContain('terrain=Terrain3D')
+    expect(url).toContain('contour-density=High')
+    expect(url).toContain('traffic=Congestion')
+    // A list goes over the wire comma-separated; the API checks each element.
+    expect(decodeURIComponent(url)).toContain('travel-modes=Truck,Transit')
+  })
+
+  it('omits what was not asked for', () => {
+    const url = buildMapStyleUrl('https://api.example.com', 'Satellite')
+    expect(url).toBe('https://api.example.com/maps/Satellite/descriptor')
+  })
+})


### PR DESCRIPTION
Closes #18 is **not** set — this is the enum groundwork, and #18 (the static map
URL builder) is separate work that will consume these types.

## Two of the types were wrong, not merely missing

| parameter | was typed | actually accepted |
|---|---|---|
| `contourDensity` | `'Medium'` only | **High, Low, Medium** |
| `traffic` | `'All'` only | **All, Congestion** |
| `mapStyle` | bare `string` | now a `MapStyle` union |

A TypeScript consumer **could not request `contourDensity: 'High'` or
`traffic: 'Congestion'`** even though the API has always accepted them. The doc
comment claiming *"Only 'Medium' is currently supported by the AWS SDK"* was
false — all three were confirmed against the live geo-maps API and against the
deployed sandbox.

## Values, not only types

`src/maps/mapEnums.ts` exports each list as a **value** as well as a type:

```
MAP_STYLES · STATIC_MAP_STYLES · COLOR_SCHEMES · TERRAINS · BUILDINGS
CONTOUR_DENSITIES · TRAFFIC_MODES · TRAVEL_MODES · SPRITE_VARIANTS
LABEL_SIZES · SCALE_BAR_UNITS · MAP_FEATURE_MODES
```

A type union gives compile-time safety and nothing to iterate, so every consumer
rendering a style picker retypes the same list into a `<select>` — and those
copies drift the moment AWS adds a style. A dropdown is now `MAP_STYLES.map(...)`
and cannot disagree with the type beside it.

This matters more since location-service-api#89, which made the API **reject** a
wrong-cased value rather than forwarding it for Amazon to answer with an
unhelpful 404. Taking values from here makes the case right by construction.

## Two distinctions worth keeping

**`STATIC_MAP_STYLES` is narrower than `MAP_STYLES`** — `/maps/static/*` takes
only Satellite and Standard; Hybrid and Monochrome are a 400 there. A test pins
that the lists stay different so nobody "tidies" them into one.

**Membership is not combination.** `Traffic: 'All'` is valid and
`Style: 'Satellite'` is valid, but together they are not —
`400 "Traffic is not supported for style."` Amazon owns that rule per request
and the API forwards its message verbatim; nothing here tries to encode it,
because it changes without an SDK release.

## Verified

- Every kebab-case parameter the client emits — `color-scheme`,
  `contour-density`, `travel-modes`, `terrain`, `traffic` — returns **200**
  against the redeployed sandbox, individually and combined
- Both values the old types forbade (`contour-density=High`,
  `traffic=Congestion`) return 200
- **163 tests pass**, 23 new: the lists are pinned by value, not merely typed,
  so an SDK change that the API regenerates fails here and says so
- Also pinned: no two values in a list differ only by case, and every value
  starts capitalised — both properties the case-sensitive API depends on
- `npm run build` and `npm run lint` clean

## No change needed in client-react

It does not re-export client types, so consumers already import them from
`@chaosity/location-client` directly.

## Next

This needs `/publish-lib client minor` before the testbed can use it — `^0.3.0`
cannot reach new exports until they are on npm. **Minor rather than patch**:
narrowing `mapStyle` from `string` to a union is technically breaking for anyone
passing a computed string, and on `0.x` the minor is the only boundary npm
enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
