### PR TITLE
Release v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release **v0.4.0** — a **minor**, deliberately.

## Why minor rather than patch

`buildMapStyleUrl` and `fetchMapStyle` previously took `mapStyle: string`; they
now take a `MapStyle` union. **That is breaking for anyone passing a computed
string**, and on `0.x` the minor is the only incompatibility boundary npm
enforces — `^0.3.0` will not resolve `0.4.0`, which is exactly the protection
consumers should get here.

## What is in it

Since `v0.3.0`:

- `557938d` **Export the map parameter values, and fix two that were wrong** (#18)
- `d8e025d` Cover the four files that had no tests at all (#6)

### Two types were narrower than the API

| parameter | was typed | actually accepted |
|---|---|---|
| `contourDensity` | `'Medium'` only | **High, Low, Medium** |
| `traffic` | `'All'` only | **All, Congestion** |

A TypeScript consumer could not request `contourDensity: 'High'` or
`traffic: 'Congestion'` even though the API has always accepted them, and the
doc comment claiming *"Only 'Medium' is currently supported by the AWS SDK"* was
simply false. Both were confirmed against the live geo-maps API and the
deployed sandbox.

### The enums are exported as values, not only types

```
MAP_STYLES · STATIC_MAP_STYLES · COLOR_SCHEMES · TERRAINS · BUILDINGS
CONTOUR_DENSITIES · TRAFFIC_MODES · TRAVEL_MODES · SPRITE_VARIANTS
LABEL_SIZES · SCALE_BAR_UNITS · MAP_FEATURE_MODES
```

A union gives compile-time safety and nothing to iterate, so consumers retype
the list into a `<select>` and the copy drifts. A picker is now
`MAP_STYLES.map(...)`. This matters more since location-service-api#89 made the
API **reject** wrong-cased values rather than forwarding them — taking values
from here makes the case right by construction.

## Verified (§1 gate)

- working tree clean, on `main`, fast-forward pull
- `npm ci --dry-run` clean — no lockfile drift
- `npm run lint`, `npm test` (163), `npm run build` all exit 0
- every kebab-case parameter the client emits returns **200** against the
  redeployed sandbox, including the two values the old types forbade

## Consumers: what this does NOT break, and what it does

`@chaosity/address-form` declares `location-client >=0.3.0` — **resolves 0.4.0
fine**.

`@chaosity/location-client-react@0.3.1` declares `^0.3.0` as a hard
**dependency**, which cannot cross to `0.4.0`. Nothing breaks, but an app on
client 0.4.0 will get a **second nested copy** at 0.3.x. That needs its own
range bump and release next — it is not a fault in this one, but it should not
sit for long, since two module instances make `instanceof` fail across the
boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
