### PR TITLE
Keep the API's message when a style request fails

### DIFF
--- a/src/maps/mapStyle.ts
+++ b/src/maps/mapStyle.ts
@@ -1,4 +1,6 @@
 import type { StyleSpecification } from 'maplibre-gl'
+
+import { parseErrorResponse } from '../transport/errors'
 import type {
   Buildings,
   ColorScheme,
@@ -120,8 +122,23 @@ export async function fetchMapStyle(
   })
 
   if (!response.ok) {
-    throw new Error(
-      `Failed to fetch map style: ${response.status} ${response.statusText}`,
+    // Read the body. The API sends `{message, code, requestId}` and the message
+    // is the whole point of it — for a style request it is Amazon's own
+    // sentence, forwarded verbatim by location-service-api#89:
+    //
+    //   400 "Traffic is not supported for style."
+    //   400 "light is not a supported color scheme for style Standard."
+    //
+    // This used to throw `Failed to fetch map style: 400`, discarding all of it
+    // two lines before anyone could read it — the same defect #89 fixed in the
+    // API, one layer up. Reuses parseErrorResponse so a style failure arrives as
+    // the same LocationServiceException as every other call in this package,
+    // with `code`, `statusCode` and `requestId` intact.
+    throw parseErrorResponse(
+      response.status,
+      response.statusText,
+      await response.text(),
+      response.headers,
     )
   }
 

--- a/test/map-style-errors.test.ts
+++ b/test/map-style-errors.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { LocationServiceException, fetchMapStyle } from '../src/index'
+
+/**
+ * A failed style request keeps the API's message.
+ *
+ * `fetchMapStyle` used to throw `Failed to fetch map style: 400`, built from the
+ * status alone. The body was never read — so the sentence the API had gone to
+ * some trouble to forward was discarded two lines before anyone could see it:
+ *
+ *   API:    400 {"message":"Traffic is not supported for style.", ...}
+ *   client: Error: Failed to fetch map style: 400
+ *
+ * That is the same defect location-service-api#89 fixed on the server, one layer
+ * up: a useful message thrown away because the code discriminated on the wrong
+ * thing. Found by driving the testbed, not by a test — which is why these exist.
+ *
+ * NOTE ON THE MOCK: `mockImplementation`, not `mockResolvedValue`. A `Response`
+ * body can be consumed once, so a single shared instance makes the second
+ * assertion fail with "Body is unusable" from somewhere inside the transport.
+ */
+
+const json = (
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  })
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const call = () =>
+  fetchMapStyle('https://api.example.com', 'Satellite', () => 'tok', {
+    traffic: 'Congestion',
+  })
+
+describe("the API's own message survives", () => {
+  it('surfaces the combination error Amazon reports', async () => {
+    // Membership is checked locally by the API; COMBINATIONS are Amazon's rule
+    // and arrive per request, so this sentence cannot be predicted client-side.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async () =>
+        json(400, {
+          message: 'Traffic is not supported for style.',
+          code: 'ValidationException',
+          requestId: 'req-1',
+        }),
+      ),
+    )
+
+    await expect(call()).rejects.toThrow('Traffic is not supported for style.')
+  })
+
+  it('arrives as a LocationServiceException, like every other call', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async () =>
+        json(400, {
+          message: 'light is not a supported color scheme for style Standard.',
+          code: 'ValidationException',
+          requestId: 'req-2',
+        }),
+      ),
+    )
+
+    // Imported from the same module graph as the code under test, or the
+    // instanceof check compares two different class objects.
+    await expect(call()).rejects.toBeInstanceOf(LocationServiceException)
+  })
+
+  it('keeps code, statusCode and requestId', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async () =>
+        json(400, {
+          message: 'Traffic is not supported for style.',
+          code: 'ValidationException',
+          requestId: 'req-3',
+        }),
+      ),
+    )
+
+    const err = await call().catch(
+      (e: unknown) => e as LocationServiceException,
+    )
+    expect(err.code).toBe('ValidationException')
+    expect(err.statusCode).toBe(400)
+    expect(err.requestId).toBe('req-3')
+  })
+
+  it('handles a 406 from the binary Accept guard', async () => {
+    // The descriptor is text and is not gated, but a caller can still reach a
+    // 406 through this function if the API ever gates more (api#92).
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async () =>
+        json(406, {
+          message:
+            "This endpoint returns application/x-protobuf; send 'Accept: …'",
+          code: 'NotAcceptableException',
+          requestId: 'req-4',
+        }),
+      ),
+    )
+
+    const err = await call().catch(
+      (e: unknown) => e as LocationServiceException,
+    )
+    expect(err.statusCode).toBe(406)
+    expect(err.code).toBe('NotAcceptableException')
+    expect(err.message).toContain('application/x-protobuf')
+  })
+})
+
+describe('a body that is not our envelope still says something useful', () => {
+  it('falls back to the raw body when it is not JSON', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(
+        async () =>
+          new Response('<html>502 Bad Gateway</html>', {
+            status: 502,
+            statusText: 'Bad Gateway',
+          }),
+      ),
+    )
+
+    const err = await call().catch(
+      (e: unknown) => e as LocationServiceException,
+    )
+    expect(err.statusCode).toBe(502)
+    expect(err.message).toContain('502 Bad Gateway')
+  })
+
+  it('falls back to the status when the body is empty', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementation(
+          async () =>
+            new Response('', { status: 401, statusText: 'Unauthorized' }),
+        ),
+    )
+
+    const err = await call().catch(
+      (e: unknown) => e as LocationServiceException,
+    )
+    expect(err.statusCode).toBe(401)
+    expect(err.message).toContain('Unauthorized')
+  })
+})
+
+describe('a successful style is still returned untouched', () => {
+  it('parses and returns the descriptor', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementation(async () =>
+          json(200, { version: 8, sources: {}, layers: [] }),
+        ),
+    )
+
+    const style = await fetchMapStyle(
+      'https://api.example.com',
+      'Standard',
+      () => 'tok',
+    )
+    expect(style.version).toBe(8)
+  })
+})

--- a/test/maps.test.ts
+++ b/test/maps.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LocationServiceException } from '../src/errors/LocationServiceException'
 import { createTransformRequest } from '../src/maps/createTransformRequest'
 import { applyMapLanguage } from '../src/maps/mapLanguage'
 import {
@@ -158,12 +159,24 @@ describe('fetchMapStyle', () => {
     expect(init.headers.Accept).toBe('application/json')
   })
 
-  it('throws with the status when the API refuses', async () => {
+  it('carries the status when the API refuses', async () => {
+    // The status used to be asserted through the MESSAGE, because the message
+    // was built from the status and nothing else. It is structural now: the
+    // message carries what the server actually said, which for our error
+    // envelope is Amazon's own sentence (see map-style-errors.test.ts).
     fetchMock.mockImplementation(
       async () =>
         new Response('nope', { status: 403, statusText: 'Forbidden' }),
     )
-    await expect(fetchMapStyle(API, 'Standard', token)).rejects.toThrow(/403/)
+
+    const err = await fetchMapStyle(API, 'Standard', token).catch(
+      (e: unknown) => e as LocationServiceException,
+    )
+    expect(err).toBeInstanceOf(LocationServiceException)
+    expect(err.statusCode).toBe(403)
+    // A non-JSON body is echoed rather than discarded — it is what the server
+    // chose to say.
+    expect(err.message).toContain('nope')
   })
 
   it('rewrites text-field on symbol layers for the requested language', async () => {


### PR DESCRIPTION
## The bug

`fetchMapStyle` threw `Failed to fetch map style: 400`, built from the status
alone — **it never read the body.** So the sentence the API forwards was
discarded two lines before anyone could see it:

```
API:    400 {"message":"Traffic is not supported for style.", ...}
client: Error: Failed to fetch map style: 400
```

That is the same defect location-service-api#89 fixed on the server, one layer
up: a useful message thrown away because the code discriminated on the wrong
thing.

It matters most for exactly the errors a client cannot predict. Membership and
case the API now checks locally, but **combinations are Amazon's rule and arrive
per request** — `Satellite` + `Traffic: All` is two legal values in an illegal
pairing, and that sentence cannot be derived client-side. Discarding it leaves
the caller with a bare `400`.

## The fix

Reuses `parseErrorResponse`, so a style failure arrives as the same
`LocationServiceException` as every other call in this package, with `code`,
`statusCode` and `requestId` intact — and the existing legacy-envelope tolerance
for bodies that are not ours.

```
before:  Error: Failed to fetch map style: 400
after:   LocationServiceException: Traffic is not supported for style.
```

## Found by driving the testbed, not by a test

Which is why there are now seven. **Six of the seven fail against the old
throw** — they would have caught it.

One existing assertion was **changed rather than deleted**: `maps.test.ts` had
*"throws with the status when the API refuses"*, matching the message against
`/403/`. That only passed because the message was built *from* the status and
nothing else. It now asserts `statusCode` structurally and that a non-JSON body
is echoed rather than discarded — same intent, better contract.

## Verified

- **170 tests pass**; lint and build clean
- in a real browser against the sandbox, the console now reads
  `LocationServiceException: Traffic is not supported for style.`

## Note

This needs a patch release before consumers see it — the testbed declares
`^0.4.0` and the published 0.4.0 still has the old throw.

**On the commit message:** two passages are missing from it. Backticks in the
body were interpreted by the shell as command substitution before git saw them,
emptying the two spots that quoted the old error string. The commit is already
pushed and the rules here forbid amending or force-pushing, so it stands as-is —
this PR body carries the full explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
