### PR TITLE
Release v0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release **v0.4.1** — a **patch**.

## Why patch and not minor

`fetchMapStyle` now throws a `LocationServiceException` where it previously threw
a bare `Error`. That is not breaking:

- `LocationServiceException` **extends `Error`**, so `catch (e) => e.message` and
  `e instanceof Error` both still work
- the package already documents `LocationServiceException` as *"the single error
  type this package throws"* — `fetchMapStyle` throwing a bare `Error` was the
  anomaly, and this brings it in line with the documented contract rather than
  changing it
- nothing that previously resolved now rejects, and no export changed shape

The only caller who would notice is one matching the old message string with a
regex, which was never a contract.

## What is in it

Since `v0.4.0`:

- `cdb36ce` **Keep the API's message when a style request fails**

`fetchMapStyle` threw `Failed to fetch map style: 400`, built from the status
alone — it never read the body. So the sentence the API forwards was discarded
two lines before anyone could see it:

```
before:  Error: Failed to fetch map style: 400
after:   LocationServiceException: Traffic is not supported for style.
```

That matters most for the errors a client cannot predict. Membership and case the
API checks locally now, but **combinations are Amazon's rule and arrive per
request** — `Satellite` + `Traffic: All` is two legal values in an illegal
pairing, and that sentence cannot be derived client-side.

It reuses `parseErrorResponse`, so a style failure now carries `code`,
`statusCode` and `requestId` like every other call in this package.

## Verified (§1 gate)

- clean tree, on `main`, fast-forward pull
- `npm ci --dry-run` clean — no lockfile drift
- `npm run lint` 0 · **170 tests pass** · `npm run build` 0
- verified in a real browser against the sandbox before merge

## Dependency order (§2)

Both dependents declare a `>=` floor, so each reaches 0.4.1 with no range bump:

| package | declares | reaches 0.4.1 |
|---|---|---|
| `@chaosity/location-client-react` | `>=0.3.0` (peer) | yes |
| `@chaosity/address-form` | `>=0.3.0` (peer) | yes |

## After this

`location-service-samples` pins 0.4.0 in its committed lockfile, so the testbed
keeps the old behaviour under `npm ci` until that lockfile moves — `^0.4.0` only
picks up 0.4.1 on a fresh resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
