### PR TITLE
Give the geocoder control features it can render

### DIFF
--- a/src/adapters/GeoPlaces.ts
+++ b/src/adapters/GeoPlaces.ts
@@ -73,6 +73,57 @@ export interface GeoPlacesOptions {
   details?: GeoPlacesDetailOptions
 }
 
+type ConvertedFeature = ReturnType<
+  typeof geocodeResponseToFeatureCollection
+>['features'][number]
+
+/**
+ * Give the control the fields it renders, not just the ones GeoJSON needs.
+ *
+ * `@maplibre/maplibre-gl-geocoder` is a Carmen-shaped consumer: its result list
+ * calls `item.place_name.split(',')`, the input takes `result.place_name` on
+ * select, and fly-to reads `center` / `bbox`. The AWS converters produce plain
+ * GeoJSON — `properties` and `geometry` only — so a forward geocode used to
+ * hand the control features with no `place_name`. The list renderer threw, the
+ * control caught it and emitted `error`, and with no listener that surfaced as
+ * `Unhandled error. (undefined)` in the console: the Enter key silently did
+ * nothing. Suggestions were unaffected because that path renders `text`.
+ *
+ * The `as MaplibreGeocoderFeatureResults` cast this replaces is what hid it —
+ * `place_name` and `text` are required on the type.
+ */
+function toCarmenFeatures(
+  features: ConvertedFeature[],
+): CarmenGeojsonFeature[] {
+  return features.map((feature) => {
+    const p = (feature.properties ?? {}) as Record<string, unknown>
+    const title = typeof p.Title === 'string' ? p.Title : ''
+    const label =
+      typeof p['Address.Label'] === 'string' ? p['Address.Label'] : ''
+    // `flattenProperties` flattens nested OBJECTS (Address.Label) but leaves an
+    // array of numbers intact, so MapView is still [minx, miny, maxx, maxy].
+    const view = p.MapView
+    const bbox =
+      Array.isArray(view) &&
+      view.length === 4 &&
+      view.every((v) => typeof v === 'number')
+        ? (view as [number, number, number, number])
+        : undefined
+    const center =
+      feature.geometry?.type === 'Point'
+        ? (feature.geometry.coordinates as [number, number])
+        : undefined
+    return {
+      ...feature,
+      text: title || label,
+      place_name: label || title,
+      place_type: typeof p.PlaceType === 'string' ? [p.PlaceType] : [],
+      ...(bbox ? { bbox } : {}),
+      ...(center ? { center } : {}),
+    } as CarmenGeojsonFeature
+  })
+}
+
 export class GeoPlaces implements MaplibreGeocoderApi {
   private client: GeoPlacesClient
   private map: Map
@@ -140,10 +191,14 @@ export class GeoPlaces implements MaplibreGeocoderApi {
     const response = (await this.client.send(
       new GeocodeCommand(commandInput),
     )) as GeocodeResponse
-    const result = geocodeResponseToFeatureCollection(response, {
+    const converted = geocodeResponseToFeatureCollection(response, {
       flattenProperties: true,
-    }) as MaplibreGeocoderFeatureResults
-    log('forwardGeocode returned %d results', result.features?.length ?? 0)
+    })
+    const result: MaplibreGeocoderFeatureResults = {
+      type: 'FeatureCollection',
+      features: toCarmenFeatures(converted.features),
+    }
+    log('forwardGeocode returned %d results', result.features.length)
     return result
   }
 
@@ -166,10 +221,14 @@ export class GeoPlaces implements MaplibreGeocoderApi {
     const response = (await this.client.send(
       new ReverseGeocodeCommand(commandInput),
     )) as ReverseGeocodeResponse
-    const result = reverseGeocodeResponseToFeatureCollection(response, {
+    const converted = reverseGeocodeResponseToFeatureCollection(response, {
       flattenProperties: true,
-    }) as MaplibreGeocoderFeatureResults
-    log('reverseGeocode returned %d results', result.features?.length ?? 0)
+    })
+    const result: MaplibreGeocoderFeatureResults = {
+      type: 'FeatureCollection',
+      features: toCarmenFeatures(converted.features),
+    }
+    log('reverseGeocode returned %d results', result.features.length)
     return result
   }
 

--- a/test/geoplaces-adapter.test.ts
+++ b/test/geoplaces-adapter.test.ts
@@ -124,3 +124,113 @@ describe('GetPlace detail is opt-in, so the default stays in Core', () => {
     expect(lastInput().AdditionalFeatures).toBeUndefined()
   })
 })
+
+/**
+ * The control is a Carmen-shaped consumer. Its result list renders
+ * `item.place_name.split(',')`, the input takes `place_name` on select, and
+ * fly-to reads `center` / `bbox`. The AWS converters emit plain GeoJSON, so a
+ * forward geocode used to return features with NO `place_name` — the list
+ * renderer threw, the control emitted `error` with nobody listening, and the
+ * Enter key silently did nothing (`Unhandled error. (undefined)` in the
+ * console). Found by driving the testbed, not by a test — which is why these
+ * exist. Suggestions never broke, because that path renders `text`.
+ */
+describe('results carry what the geocoder control renders', () => {
+  // The shape Amazon returns for "Circular Quay" with an AU filter, trimmed.
+  const item = (over: Record<string, unknown> = {}) => ({
+    PlaceId: 'AQAA-1',
+    PlaceType: 'Street',
+    Title: 'Circular Quay, Sydney NSW 2000, Australia',
+    Address: {
+      Label: 'Circular Quay, Sydney NSW 2000, Australia',
+      Country: { Code2: 'AU', Code3: 'AUS', Name: 'Australia' },
+      Locality: 'Sydney',
+    },
+    Position: [151.21284, -33.85985],
+    MapView: [151.2117, -33.8611, 151.2141, -33.8586],
+    Distance: 1500,
+    ...over,
+  })
+
+  const clientReturning = (response: unknown) =>
+    ({ send: async () => response }) as unknown as GeoPlacesClient
+
+  it('forward geocode: place_name, text, place_type, center and bbox are present', async () => {
+    const gp = new GeoPlaces(
+      clientReturning({ ResultItems: [item()] }),
+      fakeMap as never,
+    )
+    const { features } = await gp.forwardGeocode({
+      query: 'Circular Quay',
+    } as never)
+
+    expect(features).toHaveLength(1)
+    const f = features[0]!
+    expect(f.place_name).toBe('Circular Quay, Sydney NSW 2000, Australia')
+    expect(f.text).toBe('Circular Quay, Sydney NSW 2000, Australia')
+    expect(f.place_type).toEqual(['Street'])
+    expect(f.center).toEqual([151.21284, -33.85985])
+    expect(f.bbox).toEqual([151.2117, -33.8611, 151.2141, -33.8586])
+    // Still a valid GeoJSON feature underneath.
+    expect(f.geometry).toEqual({
+      type: 'Point',
+      coordinates: [151.21284, -33.85985],
+    })
+  })
+
+  it('survives what the list renderer does to it', async () => {
+    // This is the exact expression that threw.
+    const gp = new GeoPlaces(
+      clientReturning({ ResultItems: [item()] }),
+      fakeMap as never,
+    )
+    const { features } = await gp.forwardGeocode({ query: 'x' } as never)
+    expect(() => features[0]!.place_name.split(',')).not.toThrow()
+  })
+
+  it('falls back to Title when there is no address label', async () => {
+    const gp = new GeoPlaces(
+      clientReturning({
+        ResultItems: [item({ Address: { Country: { Code2: 'AU' } } })],
+      }),
+      fakeMap as never,
+    )
+    const { features } = await gp.forwardGeocode({ query: 'x' } as never)
+    expect(features[0]!.place_name).toBe(
+      'Circular Quay, Sydney NSW 2000, Australia',
+    )
+  })
+
+  it('omits bbox when Amazon sends no MapView, rather than inventing one', async () => {
+    const gp = new GeoPlaces(
+      clientReturning({ ResultItems: [item({ MapView: undefined })] }),
+      fakeMap as never,
+    )
+    const { features } = await gp.forwardGeocode({ query: 'x' } as never)
+    expect(features[0]).not.toHaveProperty('bbox')
+    expect(features[0]!.center).toEqual([151.21284, -33.85985])
+  })
+
+  it('reverse geocode gets the same treatment', async () => {
+    const gp = new GeoPlaces(
+      clientReturning({ ResultItems: [item()] }),
+      fakeMap as never,
+    )
+    const { features } = await gp.reverseGeocode({
+      query: [151.2093, -33.8688],
+    } as never)
+    expect(features[0]!.place_name).toBe(
+      'Circular Quay, Sydney NSW 2000, Australia',
+    )
+    expect(features[0]!.place_type).toEqual(['Street'])
+  })
+
+  it('an empty result is an empty collection, not a crash', async () => {
+    const gp = new GeoPlaces(
+      clientReturning({ ResultItems: [] }),
+      fakeMap as never,
+    )
+    const result = await gp.forwardGeocode({ query: 'zzz' } as never)
+    expect(result).toEqual({ type: 'FeatureCollection', features: [] })
+  })
+})


### PR DESCRIPTION
## What broke

Pressing Enter in a `MaplibreGeocoder` wired to `GeoPlaces` logged
`Unhandled error. (undefined)` and did nothing. Suggestions worked; only the
forward-geocode path failed.

## Why

The control is a Carmen-shaped consumer — its result list renders
`item.place_name.split(',')`, the input takes `result.place_name` on select,
and fly-to reads `center` / `bbox`. `geocodeResponseToFeatureCollection`
returns plain GeoJSON (`properties` + `geometry`), so `forwardGeocode` and
`reverseGeocode` handed the control features with **no `place_name`**. The
renderer threw, the control emitted `error`, and with no listener the
EventEmitter itself threw with the real exception discarded.

The `as MaplibreGeocoderFeatureResults` casts hid it: `place_name` and `text`
are required on the type. Removing the casts is what makes this compile-time
enforced from now on.

## Fix

`toCarmenFeatures()` fills `place_name`, `text`, `place_type`, `center`, `bbox`
from the flattened properties — what `searchByPlaceId` already did by hand for
GetPlace. `bbox` reads `properties.MapView`, which `flattenProperties` leaves
as an intact array (it flattens nested objects, not number arrays — the first
draft assumed `MapView.0..3` and a test caught it).

## Verification

- 176 tests / 9 files, prettier clean, `tsc` build clean
- 6 new tests, including the exact expression that threw
  (`features[0].place_name.split(',')`) and the adapter run against the shape
  Amazon returns for "Circular Quay" with an AU filter
- The API side was checked first: the geocode returned 200 with two valid
  results, so this is entirely client-side

Browser verification needs the package published — the testbed installs from
npm. That's the next step: patch release → bump the testbed → drive `/geocoder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
