### PR TITLE
Release v0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## v0.4.2 — patch

**Why patch:** a behaviour fix inside `GeoPlaces` — forward/reverse geocode
results now carry the Carmen fields the geocoder control renders. No export
removed or renamed, no caller-facing type changed. `^0.4.x` consumers should
receive it automatically.

## Since v0.4.1

- #23 — Give the geocoder control features it can render. Pressing Enter in a
  `MaplibreGeocoder` wired to `GeoPlaces` threw `Unhandled error. (undefined)`
  because `forwardGeocode` returned features with no `place_name`; the
  `as MaplibreGeocoderFeatureResults` casts had hidden the missing required
  fields. `toCarmenFeatures()` fills `place_name`, `text`, `place_type`,
  `center`, `bbox`; the casts are gone.

## Verification (preflight on main before the bump)

- `npm ci --dry-run` — no lockfile drift
- prettier clean · 176 tests / 9 files · `tsc` build clean
- `npm version patch` on `release/0.4.2`: bump, commit and signed tag in one step

Next: bump the testbed to 0.4.2 and drive `/geocoder` in a browser — the
real proof, since the testbed installs from npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
