### PR TITLE
Add fetchStaticMap so callers stop guessing an exact Accept header (#25)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,12 @@ export {
 export type { PoiCategory } from './maps/mapPoi'
 export { buildMapStyleUrl, fetchMapStyle } from './maps/mapStyle'
 export type { MapStyleOptions } from './maps/mapStyle'
+export {
+  buildStaticMapUrl,
+  fetchStaticMap,
+  staticMapAccept,
+} from './maps/staticMap'
+export type { StaticMapFileName, StaticMapOptions } from './maps/staticMap'
 
 // Accepted values for every map parameter, as VALUES so a picker can be built
 // from them, plus the matching types. Case sensitive — see mapEnums.ts.

--- a/src/maps/staticMap.ts
+++ b/src/maps/staticMap.ts
@@ -1,0 +1,167 @@
+import { parseErrorResponse } from '../transport/errors'
+import type {
+  ColorScheme,
+  LabelSize,
+  MapFeatureMode,
+  ScaleBarUnit,
+  StaticMapStyle,
+} from './mapEnums'
+
+/**
+ * Static maps: build the URL, send the right headers, get a Blob.
+ *
+ * This exists because `/maps/static/{fileName}` is the one map route MapLibre
+ * never requests, so `createTransformRequest` never sees it and every caller was
+ * left to hand-roll the fetch. Ours did — `nextjs-address-finder-full`'s
+ * NearbySearch.tsx carried a comment explaining the rule — which is the clearest
+ * sign it belonged in the library (client#25, api#35).
+ *
+ * Two things make a plain fetch fail, and neither is discoverable:
+ *
+ * 1. `Accept` MUST name the exact type. Measured against the sandbox on
+ *    2026-08-26: `image/png` -> 200, while `image/*`, `*\/*`, and the header a
+ *    browser sends for `<img>` all -> 406. Not even `image/*` is enough.
+ *
+ * 2. The type follows the STYLE, not the file name, and the default is
+ *    Satellite:
+ *
+ *      Standard   -> image/png
+ *      Satellite  -> image/jpeg   <- the default when `style` is omitted
+ *
+ *    So the naive `Accept: image/png` is wrong for the DEFAULT request. The API
+ *    hit the mirror image of this bug itself: it hard-coded image/png on the
+ *    response and labelled every default render — a JPEG — as a PNG.
+ *
+ * `<img src="...">` cannot be made to work: it sends neither `Authorization` nor
+ * an acceptable `Accept`. Fetching to a Blob is the only viable shape, which is
+ * why this returns one rather than a URL.
+ */
+
+/** `map`, or `map@2x` for a retina render. There is no file extension. */
+export type StaticMapFileName = 'map' | 'map@2x'
+
+export interface StaticMapOptions {
+  /** Pixels, 64-1500. */
+  width: number
+  /** Pixels, 64-1500. */
+  height: number
+
+  // Exactly ONE of the three below is required. The API rejects zero or more
+  // than one with a message naming which were given.
+
+  /** `[longitude, latitude]`. */
+  center?: [number, number]
+  /** `[west, south, east, north]`. */
+  boundingBox?: [number, number, number, number]
+  /** Positions the render must contain, as `[lng, lat]` pairs. */
+  boundedPositions?: Array<[number, number]>
+
+  zoom?: number
+  radius?: number
+  padding?: number
+  cropLabels?: boolean
+  style?: StaticMapStyle
+  colorScheme?: ColorScheme
+  labelSize?: LabelSize
+  /**
+   * `Enabled` | `Disabled` -- NOT a list of categories. api#35 records this
+   * being passed as a string array against the SDK's Enabled|Disabled type,
+   * working only by stringification. Typed here so that cannot recur.
+   */
+  pointsOfInterests?: MapFeatureMode
+  scaleBarUnit?: ScaleBarUnit
+  /** Defaults to `map`. */
+  fileName?: StaticMapFileName
+}
+
+/**
+ * The Accept header this request must send.
+ *
+ * Exported because it is the one rule a caller cannot guess, and anyone doing
+ * their own fetch — a server-side render, a proxy — needs it too. Satellite is
+ * the default, so an absent style means JPEG.
+ */
+export function staticMapAccept(style?: StaticMapStyle): string {
+  return style === 'Standard' ? 'image/png' : 'image/jpeg'
+}
+
+/** Build the request URL without fetching it. */
+export function buildStaticMapUrl(
+  apiUrl: string,
+  options: StaticMapOptions,
+): string {
+  const {
+    width,
+    height,
+    center,
+    boundingBox,
+    boundedPositions,
+    fileName = 'map',
+    ...rest
+  } = options
+
+  const params = new URLSearchParams({
+    width: String(width),
+    height: String(height),
+  })
+
+  // Positions go over the wire as comma-separated numbers. api#35 records that
+  // passing arrays straight through worked only by accidental stringification;
+  // doing it explicitly here means the shape is ours, not JavaScript's default.
+  if (center) params.set('center', center.join(','))
+  if (boundingBox) params.set('bounding-box', boundingBox.join(','))
+  if (boundedPositions) {
+    params.set('bounded-positions', boundedPositions.flat().join(','))
+  }
+
+  // The API accepts kebab-case on the wire and camelCase for older callers;
+  // kebab is the documented form, so emit that.
+  const KEBAB: Record<string, string> = { cropLabels: 'crop-labels' }
+  for (const [key, value] of Object.entries(rest)) {
+    if (value === undefined) continue
+    params.set(KEBAB[key] ?? key, String(value))
+  }
+
+  return `${apiUrl}/maps/static/${fileName}?${params}`
+}
+
+/**
+ * Fetch a static map as a Blob.
+ *
+ * @param apiUrl   Base URL of the Location Service API
+ * @param options  Render options; exactly one of center / boundingBox / boundedPositions
+ * @param getToken Callback returning the current auth token
+ *
+ * @example
+ * const blob = await fetchStaticMap(API_URL, {
+ *   width: 640, height: 400, center: [151.2093, -33.8688], zoom: 14,
+ *   style: 'Standard',
+ * }, getToken)
+ * const url = URL.createObjectURL(blob)   // remember to revokeObjectURL
+ */
+export async function fetchStaticMap(
+  apiUrl: string,
+  options: StaticMapOptions,
+  getToken: () => string | undefined,
+): Promise<Blob> {
+  const response = await fetch(buildStaticMapUrl(apiUrl, options), {
+    headers: {
+      Authorization: `Bearer ${getToken()}`,
+      Accept: staticMapAccept(options.style),
+    },
+  })
+
+  if (!response.ok) {
+    // Same treatment as fetchMapStyle: the API's {message, code, requestId} is
+    // the useful part, and a bare "failed: 400" throws it away. The messages
+    // here are specific and actionable -- "'width' and 'height' are required",
+    // "Only one of center, bounding-box or bounded-positions may be set".
+    throw parseErrorResponse(
+      response.status,
+      response.statusText,
+      await response.text(),
+    )
+  }
+
+  return response.blob()
+}

--- a/test/static-map.test.ts
+++ b/test/static-map.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  buildStaticMapUrl,
+  fetchStaticMap,
+  staticMapAccept,
+} from '../src/maps/staticMap'
+
+/**
+ * The rule this file exists for: Accept must name the exact type, and the type
+ * follows the STYLE, not the file name.
+ *
+ * Measured against the sandbox on 2026-08-26 —
+ *
+ *   style=Standard   + Accept: image/png   -> 200, magic 89504e47 (PNG)
+ *   style=Satellite  + Accept: image/jpeg  -> 200, magic ffd8ffe0 (JPEG)
+ *   style=Satellite  + Accept: image/png   -> 406
+ *   any style        + Accept: image/*     -> 406
+ *   any style        + Accept: (wildcard)  -> 406
+ *
+ * Not even `image/*` is accepted. And Satellite is the DEFAULT, so the naive
+ * `Accept: image/png` is wrong for a request that omits `style` entirely —
+ * which is precisely the mistake the API made in the other direction, labelling
+ * every default JPEG render as a PNG.
+ */
+
+const API = 'https://api.example.test'
+const token = () => 'tok-123'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('staticMapAccept', () => {
+  it('is image/png only for Standard', () => {
+    expect(staticMapAccept('Standard')).toBe('image/png')
+  })
+
+  it('is image/jpeg for Satellite', () => {
+    expect(staticMapAccept('Satellite')).toBe('image/jpeg')
+  })
+
+  it('defaults to image/jpeg when no style is given, because Satellite is the default', () => {
+    // The whole trap in one assertion. Guessing image/png here yields a 406 on
+    // the most basic possible request.
+    expect(staticMapAccept(undefined)).toBe('image/jpeg')
+  })
+})
+
+describe('buildStaticMapUrl', () => {
+  const base = { width: 640, height: 400 } as const
+
+  it('puts the file name in the path and defaults it to map', () => {
+    const url = new URL(buildStaticMapUrl(API, { ...base, center: [1, 2] }))
+    expect(url.pathname).toBe('/maps/static/map')
+  })
+
+  it('honours map@2x for a retina render', () => {
+    const url = new URL(
+      buildStaticMapUrl(API, { ...base, center: [1, 2], fileName: 'map@2x' }),
+    )
+    expect(url.pathname).toBe('/maps/static/map@2x')
+  })
+
+  it('serialises center as longitude,latitude', () => {
+    const url = new URL(
+      buildStaticMapUrl(API, { ...base, center: [151.2093, -33.8688] }),
+    )
+    expect(url.searchParams.get('center')).toBe('151.2093,-33.8688')
+  })
+
+  it('serialises boundingBox and bounded positions flat, in kebab-case', () => {
+    const bb = new URL(
+      buildStaticMapUrl(API, { ...base, boundingBox: [1, 2, 3, 4] }),
+    )
+    expect(bb.searchParams.get('bounding-box')).toBe('1,2,3,4')
+
+    const bp = new URL(
+      buildStaticMapUrl(API, {
+        ...base,
+        boundedPositions: [
+          [1, 2],
+          [3, 4],
+        ],
+      }),
+    )
+    expect(bp.searchParams.get('bounded-positions')).toBe('1,2,3,4')
+  })
+
+  it('emits cropLabels as crop-labels', () => {
+    const url = new URL(
+      buildStaticMapUrl(API, { ...base, center: [1, 2], cropLabels: true }),
+    )
+    expect(url.searchParams.get('crop-labels')).toBe('true')
+    expect(url.searchParams.has('cropLabels')).toBe(false)
+  })
+
+  it('omits absent options rather than sending "undefined"', () => {
+    const url = new URL(buildStaticMapUrl(API, { ...base, center: [1, 2] }))
+    for (const key of ['zoom', 'style', 'radius', 'padding', 'colorScheme']) {
+      expect(url.searchParams.has(key), key).toBe(false)
+    }
+  })
+})
+
+describe('fetchStaticMap', () => {
+  function stubFetch(response: Response) {
+    const spy = vi.fn(async () => response)
+    vi.stubGlobal('fetch', spy)
+    return spy
+  }
+
+  it('sends the bearer token and the Accept matching the style', async () => {
+    const spy = stubFetch(new Response(new Blob(['x']), { status: 200 }))
+
+    await fetchStaticMap(
+      API,
+      { width: 640, height: 400, center: [1, 2], style: 'Standard' },
+      token,
+    )
+
+    const [, init] = spy.mock.calls[0]!
+    expect((init as RequestInit).headers).toEqual({
+      Authorization: 'Bearer tok-123',
+      Accept: 'image/png',
+    })
+  })
+
+  it('asks for jpeg when the style is omitted', async () => {
+    const spy = stubFetch(new Response(new Blob(['x']), { status: 200 }))
+
+    await fetchStaticMap(
+      API,
+      { width: 640, height: 400, center: [1, 2] },
+      token,
+    )
+
+    const [, init] = spy.mock.calls[0]!
+    expect(
+      (init as RequestInit).headers as Record<string, string>,
+    ).toMatchObject({ Accept: 'image/jpeg' })
+  })
+
+  it('returns the body as a Blob', async () => {
+    stubFetch(new Response(new Blob(['png-bytes']), { status: 200 }))
+    const blob = await fetchStaticMap(
+      API,
+      { width: 640, height: 400, center: [1, 2] },
+      token,
+    )
+    expect(blob).toBeInstanceOf(Blob)
+    expect(await blob.text()).toBe('png-bytes')
+  })
+
+  it('throws the API message rather than a bare status', async () => {
+    // A bare "failed: 400" throws away the only useful part. These messages are
+    // specific and actionable, so they must survive to the caller.
+    stubFetch(
+      new Response(
+        JSON.stringify({
+          message: "'width' and 'height' are required, in pixels",
+          code: 'ValidationException',
+          requestId: 'req-1',
+        }),
+        { status: 400, statusText: 'Bad Request' },
+      ),
+    )
+
+    await expect(
+      fetchStaticMap(API, { width: 0, height: 0, center: [1, 2] }, token),
+    ).rejects.toThrow(/width.*height.*required/i)
+  })
+})


### PR DESCRIPTION
Closes #25.

`/maps/static/{fileName}` is the one map route MapLibre never requests, so
`createTransformRequest` never sees it and every caller hand-rolls the fetch.
Ours did — `nextjs-address-finder-full`'s `NearbySearch.tsx` carries a comment
explaining the rule, which is the clearest sign it belonged in the library.

## Two things make a plain fetch fail, neither discoverable

**`Accept` must name the exact type.** Measured against the sandbox 2026-08-26:

| style | `Accept` | result |
|---|---|---|
| `Standard` | `image/png` | **200**, magic `89504e47` (PNG) |
| `Satellite` | `image/jpeg` | **200**, magic `ffd8ffe0` (JPEG) |
| `Satellite` | `image/png` | **406** |
| any | `image/*` | **406** |
| any | `*/*` | **406** |

Not even `image/*` is enough.

**The type follows the STYLE, not the file name — and Satellite is the DEFAULT.**
So the obvious `Accept: image/png` is wrong for a request that omits `style`
entirely. The API hit the mirror image of this itself: it hard-coded
`image/png` on the response and labelled every default render — a JPEG — as a
PNG.

`<img src="…">` cannot be made to work at all: it sends neither `Authorization`
nor an acceptable `Accept`. Fetching to a Blob is the only viable shape, so
that is what this returns.

## API

```ts
fetchStaticMap(apiUrl, options, getToken): Promise<Blob>
buildStaticMapUrl(apiUrl, options): string
staticMapAccept(style): string
```

`staticMapAccept` is exported deliberately — it is the one rule a caller cannot
guess, and anyone doing their own fetch (an SSR path, a proxy) needs it too.

Errors go through `parseErrorResponse` like `fetchMapStyle`, so a failure
arrives as a `LocationServiceException` carrying the API's own message —
*"'width' and 'height' are required"*, *"Only one of center, bounding-box or
bounded-positions may be set"* — instead of a bare status.

## Reusing mapEnums caught a real bug

Types come from `mapEnums` rather than being written by hand. My first draft
typed `pointsOfInterests` as `'All' | 'None'`; it is `MapFeatureMode`, i.e.
`Enabled | Disabled`. **api#35 records that exact mistake** being made against
the SDK types and working only by stringification. Typed from the enum now, so
it cannot recur.

## Verified against the live sandbox, not just mocks

The URLs and `Accept` values this produces were fetched for real:

```
Accept=image/png   -> 200 image/png    96,815 bytes  magic=89504e47
Accept=image/jpeg  -> 200 image/jpeg   17,733 bytes  magic=ffd8ffe0
Accept=image/jpeg  -> 200 image/jpeg   17,733 bytes  magic=ffd8ffe0   (style omitted)
```

13 new tests, **189 passing**, lint and `tsc` build clean.

## Known limit, deliberately not papered over

Node's `fetch` sends no `Origin`, and the API's `allowedDomain` check rejects
that — so this works from a browser but **not server-side as-is**. My live test
failed with `Origin not allowed` until I supplied one via curl. That is an API
policy question, not something the helper should work around silently.

## Follow-ups, not in this PR

- **Not published.** Nothing consumes it yet. This is a `minor` when released
  (`0.5.0`) since it adds public API — `/publish-lib minor`, not the default
  patch. `@chaosity/location-client-react` depends on `>=0.3.0`, a range not a
  caret, so no coordinated release is forced.
- **`NearbySearch.tsx` still hand-rolls it.** Simplifying the sample is in #25's
  done-when list as proof the helper is sufficient, but it consumes the
  published package, so it waits for the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
