### PR TITLE
Release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
`0.4.2` → **`0.5.0`**

## Why minor, not patch

**Nothing breaks.** Minor is not the "breaking" bump — under SemVer that is
major. Minor is "the public API grew, backwards-compatibly", which is exactly
this: three new exports plus two types.

It also matches what this repo has consistently done:

| release | change | new exports | bump |
|---|---|---|---|
| **0.4.0** | Export the map parameter values | **2** | **minor** |
| 0.4.1 | Keep the API's message when a style request fails | 0 | patch |
| 0.4.2 | Give the geocoder control features it can render | 0 | patch |

New exports → minor; behaviour fixes → patch.

## What is in it

`522c3cf` — Add `fetchStaticMap` so callers stop guessing an exact Accept header (#25)

```ts
fetchStaticMap(apiUrl, options, getToken): Promise<Blob>
buildStaticMapUrl(apiUrl, options): string
staticMapAccept(style): string
```

`/maps/static/{fileName}` is the one map route MapLibre never requests, so
`createTransformRequest` never covered it and every caller hand-rolled the
fetch — including our own sample. Two things made a plain fetch fail, neither
discoverable: `Accept` must name the **exact** type (`image/*` gets a 406), and
the type follows the **style**, with Satellite as the default — so the obvious
`Accept: image/png` is wrong for a request that omits `style`.

## Dependency ranges — no coordinated release forced

| dependent | range | reaches 0.5.0? |
|---|---|---|
| `@chaosity/location-client-react` | `>=0.3.0` | yes |
| `@chaosity/address-form` | `>=0.3.0` | yes |

Both use `>=`, not a caret, so neither is stranded by crossing a minor. No range
bump belongs in this PR.

## Verification (§1 gate, on the release commit)

| check | result |
|---|---|
| working tree clean, on `main`, fast-forward | pass |
| `npm ci --dry-run` (lockfile drift) | pass |
| `npm run lint` | pass |
| `npm test` | **189 passing**, 10 files |
| `npm run build` (`tsc`) | pass |

The helper was also verified against the live sandbox before merge — its URLs
and `Accept` values return 200 with correct magic bytes for Standard (PNG),
Satellite (JPEG) and style-omitted (JPEG).

## ⚠️ Known, and not addressed here

**11 sample projects are pinned `^0.1.14`** and have been stranded below 0.2.0
across three minor releases — they will not receive this one either. That is
stale pins, not a consequence of this bump, and needs its own pass over
`location-service-samples`. Only `nextjs-address-finder-full` (`^0.4.0`) tracks
anything recent.

**`NearbySearch.tsx` still hand-rolls the static-map fetch.** Simplifying it to
use the helper is #25's done-when proof, and it needs this on npm first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
