### PR TITLE
Name the unused transformRequest argument so lint is clean

### DIFF
--- a/src/maps/createTransformRequest.ts
+++ b/src/maps/createTransformRequest.ts
@@ -12,7 +12,7 @@ export function createTransformRequest(
   apiUrl: string,
   getToken: () => string | undefined,
 ): RequestTransformFunction {
-  return (url: string, resourceType?: string) => {
+  return (url: string, _resourceType?: string) => {
     if (url.startsWith(apiUrl)) {
       const token = getToken()
       if (!token) {


### PR DESCRIPTION
## What changed

`src/maps/createTransformRequest.ts` — the callback's unused second argument is renamed `resourceType` → `_resourceType`. MapLibre passes it; the function never reads it; the repo's lint rule allows an unused argument only under a leading underscore. That was the sole warning in `npm run lint`.

`npm run lint:fix` on its own changed nothing — `no-unused-vars` has no autofix and prettier was already clean — so this is the whole chore.

## Verified

- `npm run lint`: 0 problems (was 1 warning)
- `npm test`: 189/189
- `npm run build`: clean

No behaviour change; no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
