### PR TITLE
Fix the language rewrite (#28) and static-map precision (#29)

### DIFF
--- a/src/maps/mapLanguage.ts
+++ b/src/maps/mapLanguage.ts
@@ -1,15 +1,52 @@
 import type { MapLike } from '../types'
 
 /**
- * Apply a preferred display language to all symbol layers on a MapLibre map.
- *
- * AWS GeoMaps vector tiles include language-specific name properties in `name:${lang}` format
- * (e.g. `name:en`, `name:fr`, `name:ja`). This function updates the `text-field` expression
- * on every symbol layer to prefer the requested language, falling back to English then the
- * default name if the preferred language is unavailable for a feature.
+ * The `text-field` expression that prefers `language`, then English, then the
+ * feature's default name.
  *
  * Based on the approach documented at:
  * https://docs.aws.amazon.com/location/latest/developerguide/how-to-set-preferred-language-map.html
+ */
+export function languageExpression(language: string): unknown[] {
+  return language === 'en'
+    ? ['coalesce', ['get', 'name:en'], ['get', 'name']]
+    : [
+        'coalesce',
+        ['get', `name:${language}`],
+        ['get', 'name:en'],
+        ['get', 'name'],
+      ]
+}
+
+/**
+ * Whether a `text-field` reads a name property — the only kind of label a
+ * language rewrite makes sense for (#28).
+ *
+ * The AWS Standard style has 62 symbol layers with a text-field and 30 of
+ * them do NOT label by name: `building_label_number` reads
+ * `addr_housenumber`, and the 29 `shield_*` layers read `shield_text` or
+ * `ref`. Replacing those with a `name:<lang>` coalesce points them at a
+ * property their features do not carry, and the house numbers and road
+ * shields disappear — for `en` too. Measured against the live sandbox on
+ * 2026-08-29; the testbed showed it as "one map has house numbers, the
+ * others don't".
+ *
+ * Serialising the expression is the simplest exact test: `name`, `name:en`,
+ * `name_en` and a literal `{name}` template all contain it, and none of the
+ * non-name properties do.
+ */
+export function labelsByName(textField: unknown): boolean {
+  return JSON.stringify(textField)?.includes('name') ?? false
+}
+
+/**
+ * Apply a preferred display language to the name labels on a MapLibre map.
+ *
+ * AWS GeoMaps vector tiles carry `name:${lang}` properties (`name:en`,
+ * `name:fr`, `name:ja`, …). Every symbol layer whose `text-field` reads a
+ * name is rewritten to prefer the requested language, falling back to
+ * English then the default name. Layers that label by something else — house
+ * numbers, road shields — are left exactly as the style declared them.
  *
  * @param map - MapLibre Map instance (or any object matching the MapLike interface)
  * @param language - ISO 639-1 language code (e.g. 'en', 'fr', 'de', 'ja', 'zh', 'ar')
@@ -19,23 +56,14 @@ import type { MapLike } from '../types'
  */
 export function applyMapLanguage(map: MapLike, language: string): void {
   try {
-    const expression =
-      language === 'en'
-        ? ['coalesce', ['get', 'name:en'], ['get', 'name']]
-        : [
-            'coalesce',
-            ['get', `name:${language}`],
-            ['get', 'name:en'],
-            ['get', 'name'],
-          ]
+    const expression = languageExpression(language)
 
     map.getStyle().layers.forEach((layer) => {
-      if (layer.type === 'symbol') {
-        const textField = map.getLayoutProperty(layer.id, 'text-field')
-        if (textField !== undefined && textField !== null) {
-          map.setLayoutProperty(layer.id, 'text-field', expression)
-        }
-      }
+      if (layer.type !== 'symbol') return
+      const textField = map.getLayoutProperty(layer.id, 'text-field')
+      if (textField === undefined || textField === null) return
+      if (!labelsByName(textField)) return
+      map.setLayoutProperty(layer.id, 'text-field', expression)
     })
   } catch {
     // Style may not be fully loaded — call after 'style.load' event

--- a/src/maps/mapStyle.ts
+++ b/src/maps/mapStyle.ts
@@ -10,6 +10,7 @@ import type {
   TrafficMode,
   TravelMode,
 } from './mapEnums'
+import { labelsByName, languageExpression } from './mapLanguage'
 
 /**
  * Options for building an AWS Location Service map style URL.
@@ -152,29 +153,25 @@ export async function fetchMapStyle(
 }
 
 /**
- * Apply a preferred language to all symbol layers within a style descriptor object.
+ * Apply a preferred language to the name labels within a style descriptor.
  * Mutates the style in place — call before passing to MapLibre.
+ *
+ * Only a `text-field` that reads a name property is rewritten. House numbers
+ * (`addr_housenumber`) and road shields (`shield_text`) used to be rewritten
+ * too, and vanished from every map that asked for a language (#28); the rule
+ * lives in `labelsByName` so this and `applyMapLanguage` cannot disagree.
  */
 function applyLanguageToDescriptor(
   style: StyleSpecification,
   language: string,
 ): void {
-  const expression =
-    language === 'en'
-      ? ['coalesce', ['get', 'name:en'], ['get', 'name']]
-      : [
-          'coalesce',
-          ['get', `name:${language}`],
-          ['get', 'name:en'],
-          ['get', 'name'],
-        ]
+  const expression = languageExpression(language)
 
   for (const layer of style.layers) {
-    if (layer.type === 'symbol') {
-      const layout = layer.layout as Record<string, unknown> | undefined
-      if (layout?.['text-field'] !== undefined) {
-        layout['text-field'] = expression
-      }
-    }
+    if (layer.type !== 'symbol') continue
+    const layout = layer.layout as Record<string, unknown> | undefined
+    if (layout?.['text-field'] === undefined) continue
+    if (!labelsByName(layout['text-field'])) continue
+    layout['text-field'] = expression
   }
 }

--- a/src/maps/staticMap.ts
+++ b/src/maps/staticMap.ts
@@ -85,6 +85,9 @@ export function staticMapAccept(style?: StaticMapStyle): string {
   return style === 'Standard' ? 'image/png' : 'image/jpeg'
 }
 
+/** A coordinate as the API accepts it: at most six decimals, no float noise. */
+const coord = (n: number): string => String(Number(n.toFixed(6)))
+
 /** Build the request URL without fetching it. */
 export function buildStaticMapUrl(
   apiUrl: string,
@@ -108,10 +111,19 @@ export function buildStaticMapUrl(
   // Positions go over the wire as comma-separated numbers. api#35 records that
   // passing arrays straight through worked only by accidental stringification;
   // doing it explicitly here means the shape is ours, not JavaScript's default.
-  if (center) params.set('center', center.join(','))
-  if (boundingBox) params.set('bounding-box', boundingBox.join(','))
+  //
+  // Each number is rounded to six decimals (#29). The API caps a coordinate at
+  // fourteen decimals, and a value straight from `map.getCenter()` routinely
+  // has fifteen or sixteen — so the obvious "render what the user is looking
+  // at" was a 400 blaming the FORMAT. Six decimals is ~10 cm, more than a
+  // raster render can show.
+  if (center) params.set('center', center.map(coord).join(','))
+  if (boundingBox) params.set('bounding-box', boundingBox.map(coord).join(','))
   if (boundedPositions) {
-    params.set('bounded-positions', boundedPositions.flat().join(','))
+    params.set(
+      'bounded-positions',
+      boundedPositions.flat().map(coord).join(','),
+    )
   }
 
   // The API accepts kebab-case on the wire and camelCase for older callers;

--- a/test/maps.test.ts
+++ b/test/maps.test.ts
@@ -240,6 +240,51 @@ describe('fetchMapStyle', () => {
       'name',
     ])
   })
+
+  it('leaves house numbers and road shields alone — they do not label by name (#28)', async () => {
+    // The three shapes as the AWS Standard descriptor declares them. Before
+    // the fix all three became the name coalesce, and the two non-name layers
+    // then read a property their features do not have: house numbers and
+    // shields vanished from every map that asked for a language, `en`
+    // included.
+    const houseNumber = ['to-string', ['get', 'addr_housenumber']]
+    const shield = ['to-string', ['get', 'shield_text']]
+    fetchMock.mockImplementation(async () =>
+      descriptor([
+        {
+          id: 'building_label_number',
+          type: 'symbol',
+          layout: { 'text-field': houseNumber },
+        },
+        {
+          id: 'shield_generic',
+          type: 'symbol',
+          layout: { 'text-field': shield },
+        },
+        {
+          id: 'place_label',
+          type: 'symbol',
+          layout: {
+            'text-field': ['coalesce', ['get', 'name:en'], ['get', 'name']],
+          },
+        },
+      ]),
+    )
+
+    const style = await fetchMapStyle(API, 'Standard', token, {
+      language: 'fr',
+    })
+    const [number, shieldLayer, place] = style.layers as never[]
+
+    expect(number.layout['text-field']).toEqual(houseNumber)
+    expect(shieldLayer.layout['text-field']).toEqual(shield)
+    expect(place.layout['text-field']).toEqual([
+      'coalesce',
+      ['get', 'name:fr'],
+      ['get', 'name:en'],
+      ['get', 'name'],
+    ])
+  })
 })
 
 describe('POI visibility', () => {
@@ -348,6 +393,17 @@ describe('applyMapLanguage on a live map', () => {
     const { map, setLayoutProperty } = mapWith(
       [{ id: 'a', type: 'symbol' }],
       undefined,
+    )
+    applyMapLanguage(map, 'de')
+    expect(setLayoutProperty).not.toHaveBeenCalled()
+  })
+
+  it('skips a symbol layer that does not label by name (#28)', () => {
+    // A live-map language switch has the same rule as the descriptor rewrite:
+    // a house-number or shield layer keeps its own text-field.
+    const { map, setLayoutProperty } = mapWith(
+      [{ id: 'building_label_number', type: 'symbol' }],
+      ['to-string', ['get', 'addr_housenumber']],
     )
     applyMapLanguage(map, 'de')
     expect(setLayoutProperty).not.toHaveBeenCalled()

--- a/test/static-map.test.ts
+++ b/test/static-map.test.ts
@@ -69,6 +69,45 @@ describe('buildStaticMapUrl', () => {
     expect(url.searchParams.get('center')).toBe('151.2093,-33.8688')
   })
 
+  it('rounds a raw map centre so it never exceeds the API decimal cap (#29)', () => {
+    // Straight from map.getCenter(): 15 decimals. The API's POSITION rule
+    // allows 14, so this used to be
+    //   400 "'center' must be "longitude,latitude" ... got '172.515,-40.824218738262104'"
+    // — a precision cap reported as a format error, on the most obvious
+    // integration there is.
+    const url = new URL(
+      buildStaticMapUrl(API, {
+        ...base,
+        center: [172.515, -40.824218738262104],
+      }),
+    )
+    expect(url.searchParams.get('center')).toBe('172.515,-40.824219')
+
+    const bb = new URL(
+      buildStaticMapUrl(API, {
+        ...base,
+        boundingBox: [1.00000049999, 2.1234567891234, 3, 4.9999996],
+      }),
+    )
+    expect(bb.searchParams.get('bounding-box')).toBe('1,2.123457,3,5')
+
+    const bp = new URL(
+      buildStaticMapUrl(API, {
+        ...base,
+        boundedPositions: [[151.2093000001, -33.8688000000004]],
+      }),
+    )
+    expect(bp.searchParams.get('bounded-positions')).toBe('151.2093,-33.8688')
+
+    for (const value of [url, bb, bp].flatMap((u) => [
+      ...u.searchParams.values(),
+    ])) {
+      for (const n of value.split(',')) {
+        expect((n.split('.')[1] ?? '').length).toBeLessThanOrEqual(6)
+      }
+    }
+  })
+
   it('serialises boundingBox and bounded positions flat, in kebab-case', () => {
     const bb = new URL(
       buildStaticMapUrl(API, { ...base, boundingBox: [1, 2, 3, 4] }),


### PR DESCRIPTION
Closes #28, closes #29.

## #28 — the language rewrite blanked house numbers and road shields

`applyMapLanguage` (via `useMapLanguage`) and `fetchMapStyle({ language })` replaced `text-field` on **every** symbol layer with the `name:<lang>` coalesce. Measured against the live sandbox on 2026-08-29: the AWS Standard descriptor has 62 symbol layers with a `text-field`, and 30 of them don't label by name —

| Layer(s) | `text-field` |
|---|---|
| `building_label_number` (house numbers, minzoom 17) | `["to-string", ["get", "addr_housenumber"]]` |
| `shield_*` (29 road-shield layers) | `["to-string", ["get", "shield_text"]]`, `["get", "ref"]`, … |

After the rewrite those read a `name` their features don't carry, so house numbers and road shields vanished from any map that asked for a language — `en` included. In the testbed it looked like "one map shows house numbers, the others don't".

**Fix:** `mapLanguage.ts` now exports `languageExpression` and `labelsByName`; both the live-map path and the descriptor path (`mapStyle.ts`) use them and rewrite only a `text-field` that reads a name. One rule, two callers, no drift.

## #29 — static-map coordinates exceeded the API's decimal cap

`buildStaticMapUrl` serialised `center` / `boundingBox` / `boundedPositions` with `join(',')`, so a `map.getCenter()` value (15–16 decimals) went over the wire as-is. The API's `POSITION` rule allows 14 decimals and answered

```
400 ValidationException: 'center' must be "longitude,latitude", e.g. 151.2153,-33.8568 — got '172.515,-40.824218738262104'
```

— a precision cap reported as a format error, on the most obvious integration there is.

**Fix:** every coordinate is rounded to six decimals (~10 cm) before it hits the query string. `151.2093,-33.8688` still serialises exactly as before.

## Verified

- `npm test` 192/192 — three new: descriptor rewrite leaves `addr_housenumber` / `shield_text` layers alone; live-map rewrite skips non-name layers; static-map coordinates rounded, never more than 6 decimals
- `npm run build`, `npm run lint`: clean
- The same guard, running locally in the testbed (location-service-samples#25), rendered 71 house numbers at z17 in Wellington with French labels applied; the rounded static-map request returned 200 `image/png`

## Release note

Behaviour fix, no API change — semver **patch** (0.5.1). The testbed carries local copies of both workarounds to delete once this is on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
