### PR TITLE
Release v0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.5.1 — patch

**Why patch:** two behaviour fixes and a lint chore, no API change. `src/index.ts` is byte-identical to v0.5.0; the two helpers `mapLanguage.ts` now exports (`languageExpression`, `labelsByName`) are internal to the maps module and not part of the package surface. Every consumer on `^0.5.0` picks this up on their next install.

## Since v0.5.0

- `0d071da` Fix the language rewrite (#28) and static-map precision (#29) — #31
  - `applyMapLanguage` / `fetchMapStyle({ language })` rewrote `text-field` on every symbol layer; 30 of the Standard style's 62 don't label by name, so house numbers (`addr_housenumber`) and road shields (`shield_text`) vanished on any map that set a language. Only name-based labels are rewritten now, through one shared rule.
  - `buildStaticMapUrl` sent raw floats; the API caps coordinates at 14 decimals, so `map.getCenter()` was a 400. Coordinates are rounded to six decimals.
- `7a1fa41` Name the unused transformRequest argument so lint is clean — #30

## Dependencies

None moved. This is the base package; `@chaosity/location-client-react` declares a range that already reaches 0.5.1.

## Verified

- `npm ci --dry-run`: lockfile in sync
- `npm run lint`: 0 problems
- `npm test`: 192/192
- `npm run build`: clean
- The fixes were exercised against the live sandbox from the testbed (location-service-samples#25): 71 house numbers rendered at z17 with a language applied; rounded static-map request → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
