### PR TITLE
Release v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## v0.6.0 — MINOR, and why

**Minor, not patch, deliberately.** On `0.x` npm treats each minor as
incompatible, and that is the only protection consumers get. Three things in this
release can break an existing consumer:

- `@maplibre/maplibre-gl-geocoder` is no longer a runtime dependency — it is a
  devDependency plus an **optional** peer, and npm does not auto-install optional
  peers. Anyone relying on it arriving transitively must now install it.
- `main` now points at `dist/cjs/index.js` rather than `dist/index.js`.
- `engines` declares `node >=20`.

None of those fit "a fix that cannot break a caller", so they go in the minor.

## Commits since v0.5.1

```
900667f Merge pull request #43 from chaosity-io/fix/35-packaging
c94d246 Make the package loadable outside a bundler, as ESM and CJS (#35)
e74efba Merge pull request #41 from chaosity-io/ship/20260830-agent-guidance
3270a75 Add AGENTS.md: the things that cost time to rediscover
```

The substance is #43: `0.5.1` is published in a state where **every `import`
outside a bundler throws `ERR_MODULE_NOT_FOUND`** — `tsc` emitted extensionless
relative specifiers under `moduleResolution: bundler`. This release fixes that
(`NodeNext` + `.js` specifiers), adds a CommonJS build alongside the ESM one, and
adds `scripts/smoke.mjs`, which resolves `dist/` through Node as both module
systems and now runs in `prepublishOnly` — so the tarball that publishes is the
one it guards.

## Dependency ranges

No range moved in this PR. `@chaosity/location-client` is the base package and
declares no `@chaosity/*` dependency of its own.

Both dependents declare `>=0.3.0`, which is open-ended and resolves `0.6.0`
without a change:

| Package | Range | Resolves 0.6.0? |
|---|---|---|
| `@chaosity/location-client-react` | `>=0.3.0` | yes |
| `@chaosity/address-form` | `>=0.3.0` | yes |

Worth saying plainly: that is *loose*, not *correct*. `>=0.3.0` also permits
versions missing exports those packages import — one of the findings in #35 — so
those ranges still need tightening on their own release, and this PR does not do
it.

## Verification (from a clean `main`, before the bump)

| Gate | Result |
|---|---|
| `git status --porcelain` | empty |
| `npm ci --dry-run` | clean |
| `npm run lint` | clean |
| `npm test` | 192 passed, 10 files |
| `npm run build` | ESM + CJS + marker |
| `npm run smoke` | 4/4 entry-point × module-system combinations |

The packaging change itself was additionally proven end-to-end before merge: the
shipped `backend/nodejs-client-library` sample dies at startup on published
`0.5.1` and boots on this build, and a live `SearchText` against `sandbox01`
returned real results from both a plain Node ESM and a CommonJS consumer, each
installed from the packed tarball and resolved through the `exports` map.

## Not in this release

#35 stays open — the `export *` tree-shaking clause is split to #42, measured at
93,477 → 483 bytes for a map-only consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
