### PR TITLE
Fix the token leak and the unusable server connector (#34, #36, #45)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ working, and swaps SigV4 for this service's own bearer-token auth.
 ```bash
 npm run build       # tsc (ESM) + tsc -p tsconfig.cjs.json (CJS) + the CJS marker
 npm run dev         # tsc --watch
-npm test            # vitest run — 192 tests across 10 files
+npm test            # vitest run — 249 tests across 11 files
 npm run test:watch  # vitest interactive
 npm run smoke       # loads dist/ as ESM and as CJS — run it after build
 npm run lint        # eslint . AND prettier --check .
@@ -63,21 +63,70 @@ Every data request needs an `Origin` the service recognises, and it answers
 **403 without one** — server-side calls included, not just browsers. This is the
 single most common "why does my request fail" report.
 
-In a browser the browser sets it. Server-side you must, which is what
-`ConnectorConfig.origin` is for:
+In a browser the browser sets it. Server-side you must: `ConnectorConfig.origin`,
+`LOCATION_ORIGIN` in the environment, or a per-call `Origin` in `send(...)`
+headers, which overrides both.
 
-```ts
-const connector = new LocationServiceConnector({
-  apiUrl,
-  origin: 'https://your-allowed-domain.example',
-  getToken,
-})
-```
+**Exactly one of each system header must leave, whatever the caller
+capitalised.** `fetch` builds its `Headers` by APPENDING, not replacing, so a
+record carrying both `Origin` and `origin` goes out as `Origin: a, b`. Spreading
+the system headers last is NOT enough — it only out-ranks a caller key spelled
+identically. The consequences differ by header and both are real:
 
-A per-call `Origin` in `send(...)` headers still overrides the connector default.
+- `Origin: default, per-call` — the API matches the allowed domain exactly, so
+  it 403s. Two keys with the same value fare no better (`Origin: x, x`).
+- `Authorization: Bearer not-yours, Bearer <real>` — worse than a failed
+  override: a caller's lowercase `authorization` **corrupts** the token rather
+  than being ignored by it.
+
+So `dispatch` drops the caller's spelling of every header it sets — the list is
+`SYSTEM_HEADERS`, kept beside `withoutHeaders`, and it must gain any header the
+record gains. Origin's value comes from `effectiveOrigin`, which the 403
+explanation also reads, so the merge and the explanation cannot disagree about
+whether an Origin was sent; removing the duplicate never overrides the caller's
+intent.
+
+`LocationServiceConnector` is the only place in the package that merges
+caller-supplied headers at all — `GeoPlacesClient`'s `SendOptions` is
+`RequestOptions`, with no `headers` — so if you add a second such site, this is
+the trap.
 
 `/auth/token` is the exception — it is the one endpoint that does not require an
 Origin.
+
+## `LocationServiceConnector` completes its config; it does not replace it
+
+The constructor used to be all-or-nothing —
+`config ? Promise.resolve(config) : getClientConfig()` — and the consequence was
+that **neither documented form could make a successful data call** (#45). The
+zero-argument form read credentials from the environment but had no `origin`, so
+every data request 403'd; `{ origin }`, the obvious repair, took the other branch
+and had no credentials at all.
+
+So: an explicit `token` or `getToken` wins outright — a caller managing its own
+credentials must never have another application's substituted underneath it —
+and **anything short of that is filled in from the environment** (`LOCATION_API_URL`,
+`LOCATION_CLIENT_ID`, `LOCATION_CLIENT_SECRET`, `LOCATION_ORIGIN`, and the
+`LOCATION_SERVICE_*` spellings). Keep that shape when adding a field.
+
+The two ways of supplying a token are not equivalent, and the difference is not
+cosmetic: `token` is a fixed string that dies at its own `exp`, while `getToken`
+and the environment path are LIVE — asked on every request, and asked again with
+`forceRefresh: true` when the API answers 401. Prefer live sources in docs and
+samples.
+
+## `getClientConfig` must keep returning plain data
+
+`{ apiUrl, token, expiresAt }` — no methods, no closures, and this is load-bearing.
+Every Next.js sample returns it straight out of a `'use server'` action to a
+Client Component, and the RSC boundary serialises the result: a function on the
+object throws there. #36 proposed adding `getToken` to it; that would have broken
+every one of them.
+
+A caller needing a token that refreshes wants `LocationServiceConnector` (which
+holds `serverTokenSource` internally) or `TokenProvider` directly.
+`test/get-client-config.test.ts` asserts the shape so the mistake cannot be made
+quietly.
 
 ## Versioning: the caret trap on `0.x`
 
@@ -145,6 +194,17 @@ working around them.
   not make them a hard requirement for consumers who only use the Places
   commands — a consumer who never touches the map surface should not download
   them at all.
+- **Whether a URL gets the bearer token is a URL comparison, never a string
+  prefix.** `url.startsWith(apiUrl)` matched `https://api.example.com.evil.test`
+  against `https://api.example.com` and handed the customer's token to it (#34);
+  a style descriptor is data, so its sprite/glyphs/source URLs are the style
+  author's choice. `createTransformRequest` compares `origin` and requires the
+  path prefix at a `/` boundary, and fails closed on anything unparseable.
+- **A 401 is retried once; a 403 never is.** Both send paths refresh and retry
+  on 401 only, and only when the replacement is genuinely a different token —
+  the API's 403s (Origin not allowed, no domain configured) cannot be fixed by a
+  new token, and re-sending a doomed request bills for it twice. `isTokenRejected`
+  in `transport/errors.ts` is the single place that decides.
 - Tests are vitest and live in `test/`, not beside the source. New behaviour
   needs one; the suite is the only thing standing between a refactor and a
   silent break in a published package.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Set these environment variables:
 LOCATION_API_URL=https://api.chaosity.cloud
 LOCATION_CLIENT_ID=your-client-id
 LOCATION_CLIENT_SECRET=your-client-secret
+
+# Only for LocationServiceConnector: the Origin sent on every data request.
+# The API answers 403 without one it recognises — see below.
+LOCATION_ORIGIN=https://your-allowed-domain.example
 ```
 
 Or pass credentials explicitly:
@@ -207,12 +211,23 @@ const client = new GeoPlacesClient({
   apiUrl: string,
   token: string,
   getToken?: () => string | undefined, // Optional: dynamic token getter
+  refreshToken?: () => Promise<string | undefined>, // Optional: 401 self-heal
 })
 
 await client.send(command)
 ```
 
 When `getToken` is provided, it is called on every request so token updates are reflected without recreating the client.
+
+`refreshToken` covers the case `getToken` cannot. `getToken` is synchronous —
+MapLibre's `transformRequest` requires that — so it can only ever return the
+token already in hand, and a token the API stops accepting **before** its `exp`
+(revoked, or issued against a since-rotated secret) fails every request until
+the refresh buffer elapses. `refreshToken` is awaited after a 401, and the
+request is retried **once** with what it returns. Return the same token, or
+nothing, and no retry is sent — a request that is going to fail again is not
+worth being billed for twice. A 403 is never retried: a new token cannot fix an
+`Origin` the application does not allow.
 
 #### GeoPlaces Adapter
 
@@ -351,7 +366,18 @@ import { getClientConfig } from '@chaosity/location-client/server'
 
 const config = await getClientConfig()
 // { apiUrl: string, token: string, expiresAt?: number }
+
+// The API has rejected a token that has not reached its exp — revoked in the
+// portal, or issued against a client secret that has since been rotated.
+const replacement = await getClientConfig({ forceRefresh: true })
 ```
+
+The return value is **plain data** — no methods, no closures — so it can be
+returned straight out of a Next.js Server Action to a Client Component. It is
+therefore a snapshot: the token in it stops working at its `expiresAt`, and the
+caller asks for another. For a long-lived server process that should just keep
+working, use `LocationServiceConnector`, which holds a live token source and
+refreshes for you.
 
 #### TokenProvider
 
@@ -371,14 +397,18 @@ const { success, token, expiresAt } = await provider.getToken()
 
 #### LocationServiceConnector
 
-Server-side connector for backend-to-backend API calls. Can auto-configure from environment variables when no config is passed.
+Server-side connector for backend-to-backend API calls. It **completes** its
+configuration from the environment rather than replacing it, so you supply only
+the parts the environment does not have:
 
 ```typescript
 import { LocationServiceConnector } from '@chaosity/location-client/server'
 
+// apiUrl + credentials from LOCATION_API_URL / LOCATION_CLIENT_ID /
+// LOCATION_CLIENT_SECRET; Origin from here. Set LOCATION_ORIGIN as well and
+// `new LocationServiceConnector()` needs no arguments at all.
 const connector = new LocationServiceConnector({
-  apiUrl: config.apiUrl,
-  token: config.token,
+  origin: 'https://your-allowed-domain.example',
 })
 
 const result = await connector.send(
@@ -386,9 +416,34 @@ const result = await connector.send(
 )
 ```
 
+**Every data request needs an `Origin` the service recognises, and the API
+answers 403 without one** — server-to-server calls included, not just browsers.
+In a browser the browser sets it; here you do, with `origin` above,
+`LOCATION_ORIGIN`, or a per-call header (`send(cmd, { headers: { Origin } })`,
+which wins over both). `/auth/token` is the one endpoint exempt.
+
+A connector configured this way keeps working indefinitely: it holds a live
+token source, refreshes before expiry, and retries once with a new token if the
+API rejects the one it sent. Pass an explicit `token` instead and you opt out of
+all of that — it is a fixed string, and it dies at its own `exp`:
+
+```typescript
+// Managing credentials yourself: an explicit token source wins outright, and
+// the environment is not consulted.
+const connector = new LocationServiceConnector({
+  apiUrl,
+  origin: 'https://your-allowed-domain.example',
+  getToken: (forceRefresh) => provider.getToken(forceRefresh),
+})
+```
+
 ## Cache-Friendly Position Rounding
 
-`BiasPosition` coordinates are automatically rounded to 2 decimal places (~1.1 km grid) before each API request. This maximizes cache hits across nearby users without affecting result quality — bias is approximate by nature.
+`BiasPosition` coordinates are automatically rounded before each API request, to
+whatever precision your application is entitled to — a `biasDecimals` claim on
+the access token, defaulting to **3 decimal places** (~110 m) when the token
+carries none. This maximizes cache hits across nearby users without affecting
+result quality — bias is approximate by nature.
 
 `QueryPosition` (reverse geocode) retains full precision since it represents an exact point the user selected.
 

--- a/src/client/GeoPlacesClient.ts
+++ b/src/client/GeoPlacesClient.ts
@@ -1,5 +1,6 @@
 import debug from 'debug'
 import { resolveEndpoint } from '../transport/endpoints.js'
+import { isTokenRejected } from '../transport/errors.js'
 import type { RequestOptions } from '../transport/http.js'
 import { requestJson } from '../transport/http.js'
 import type { ClientConfig, GeoPlacesCommand } from '../types/index.js'
@@ -43,8 +44,12 @@ export class GeoPlacesClient {
    * case until one is configured in the portal.
    */
   getAppConfig(): AppConfigClaims {
-    const token = this.clientConfig.getToken?.() ?? this.clientConfig.token
-    return readAppConfigClaims(token)
+    return readAppConfigClaims(this.currentToken())
+  }
+
+  /** Prefer the getToken callback (live ref) over a static token string. */
+  private currentToken(): string | undefined {
+    return this.clientConfig.getToken?.() ?? this.clientConfig.token
   }
 
   /**
@@ -56,19 +61,48 @@ export class GeoPlacesClient {
     options?: SendOptions,
   ): Promise<TOutput> {
     const cmd = command as unknown as GeoPlacesCommand
-    const endpoint = resolveEndpoint(cmd)
+    const url = `${this.clientConfig.apiUrl}${resolveEndpoint(cmd)}`
+    const token = this.currentToken()
 
-    // Prefer the getToken callback (live ref) over a static token string.
-    const token = this.clientConfig.getToken?.() ?? this.clientConfig.token
+    try {
+      return await this.dispatch<TOutput>(url, token, cmd, options)
+    } catch (err) {
+      if (!isTokenRejected(err)) throw err
 
+      // One shot. `refreshToken` is the only way to actually obtain a new
+      // token here — `getToken` is synchronous and returns the one already in
+      // hand — but it is re-read as a fallback because a provider that
+      // refreshes in the background may have landed a new one while this
+      // request was in flight.
+      const fresh =
+        (await this.clientConfig.refreshToken?.()) ?? this.currentToken()
+
+      // Nothing new to send. Repeating the request would fail identically, and
+      // be billed identically.
+      if (!fresh || fresh === token) throw err
+
+      log(
+        '401 — retrying %s once with a refreshed token',
+        cmd.constructor?.name,
+      )
+      return await this.dispatch<TOutput>(url, fresh, cmd, options)
+    }
+  }
+
+  private dispatch<TOutput>(
+    url: string,
+    token: string | undefined,
+    cmd: GeoPlacesCommand,
+    options?: SendOptions,
+  ): Promise<TOutput> {
     // Resolve the token BEFORE rounding: the precision this application is
     // entitled to is a claim on it (api#65). Absent claim -> the 3 dp floor.
     const { biasDecimals } = readAppConfigClaims(token)
     const input = roundPositionFields(cmd.input, biasDecimals)
 
-    log('Sending %s to %s', cmd.constructor?.name, endpoint)
+    log('Sending %s to %s', cmd.constructor?.name, url)
     return requestJson<TOutput>(
-      `${this.clientConfig.apiUrl}${endpoint}`,
+      url,
       {
         method: 'POST',
         headers: {

--- a/src/maps/createTransformRequest.ts
+++ b/src/maps/createTransformRequest.ts
@@ -1,8 +1,56 @@
 import type { RequestTransformFunction } from 'maplibre-gl'
 
 /**
+ * Does this URL belong to our API?
+ *
+ * This decides who receives the customer's bearer token, and it used to be
+ * `url.startsWith(apiUrl)` — a string test standing in for a URL test. For
+ * `apiUrl = "https://api.example.com"`, the host `api.example.com.evil.test`
+ * is a prefix match, so a style referencing
+ * `https://api.example.com.evil.test/tiles/1/2/3` was handed
+ * `Authorization: Bearer <token>` and the token left the building (#34).
+ *
+ * That is reachable because a style descriptor is DATA: its `sprite`, `glyphs`
+ * and `sources` entries are URLs the style author chose, and MapLibre asks
+ * transformRequest about every one of them. Any style not wholly ours — a
+ * customer's own, or one edited through a tool — can name a host it likes.
+ *
+ * Compared as URLs instead, which also gets host case-folding, default ports
+ * (`https://api.test:443` === `https://api.test`) and userinfo right for free,
+ * and adds a path check so a shared host serving another tenant under a
+ * different base path is not "ours" either.
+ *
+ * Fails CLOSED: anything that will not parse gets no token. The only way to
+ * reach that is a relative `apiUrl` in a runtime with no `location` to resolve
+ * it against — i.e. not a browser, which is the only place MapLibre runs.
+ */
+function isOurApi(url: string, apiUrl: string): boolean {
+  const base = typeof location === 'undefined' ? undefined : location.href
+
+  let ours: URL
+  let theirs: URL
+  try {
+    ours = new URL(apiUrl, base)
+    theirs = new URL(url, base)
+  } catch {
+    return false
+  }
+
+  if (theirs.origin !== ours.origin) return false
+
+  // Trailing slashes normalised so `/v1` and `/v1/` behave the same; the `/`
+  // boundary is what stops `/v1` from matching `/v1-internal`.
+  const basePath = ours.pathname.replace(/\/+$/, '')
+  return (
+    theirs.pathname === basePath || theirs.pathname.startsWith(`${basePath}/`)
+  )
+}
+
+/**
  * Creates a transformRequest function for MapLibre that adds authentication
  * and proper Accept headers for AWS Location Service API requests.
+ *
+ * The token is attached to our own API and nowhere else — see isOurApi.
  *
  * @param apiUrl - Base URL of the Location Service API
  * @param getToken - Callback function that returns the current auth token
@@ -13,7 +61,7 @@ export function createTransformRequest(
   getToken: () => string | undefined,
 ): RequestTransformFunction {
   return (url: string, _resourceType?: string) => {
-    if (url.startsWith(apiUrl)) {
+    if (isOurApi(url, apiUrl)) {
       const token = getToken()
       if (!token) {
         console.warn('[createTransformRequest] No token available')

--- a/src/server/LocationServiceConnector.ts
+++ b/src/server/LocationServiceConnector.ts
@@ -1,31 +1,137 @@
 import debug from 'debug'
 import { LocationServiceException } from '../errors/LocationServiceException.js'
 import { resolveEndpoint } from '../transport/endpoints.js'
+import { isTokenRejected } from '../transport/errors.js'
 import type { RequestOptions } from '../transport/http.js'
 import { requestJson } from '../transport/http.js'
 import type { GeoPlacesCommand } from '../types/index.js'
 import { roundPositionFields } from '../utils/roundPosition.js'
 import type { AppConfigClaims } from '../utils/tokenClaims.js'
 import { readAppConfigClaims } from '../utils/tokenClaims.js'
-import type { ServerClientConfig } from './getClientConfig.js'
-import { getClientConfig } from './getClientConfig.js'
+import { resolveApiUrl, serverTokenSource } from './getClientConfig.js'
 
 const log = debug('location-client:connector')
 
 export interface ConnectorConfig {
+  /** Falls back to `LOCATION_API_URL` / `LOCATION_SERVICE_API_URL`. */
   apiUrl?: string
+  /**
+   * A fixed token. Nothing can refresh it, so it dies at its own `exp` — pass
+   * `getToken` instead, or nothing at all, for a connector that keeps working.
+   */
   token?: string
-  getToken?: () => Promise<{ token: string }>
+  /**
+   * Where a token comes from. Called for every request, so this is what makes
+   * a long-lived connector survive expiry.
+   *
+   * `forceRefresh` is passed as `true` when the API has just rejected the token
+   * this returned — the signature is `TokenProvider.getToken`'s exactly, so
+   * `getToken: (f) => provider.getToken(f)` is a complete implementation.
+   */
+  getToken?: (
+    forceRefresh?: boolean,
+  ) => Promise<string | { token?: string } | undefined>
+  /** Falls back to `LOCATION_CLIENT_ID` / `LOCATION_SERVICE_CLIENT_ID`. */
+  clientId?: string
+  /** Falls back to `LOCATION_CLIENT_SECRET` / `LOCATION_SERVICE_CLIENT_SECRET`. */
+  clientSecret?: string
   /**
    * Sent as the `Origin` header on every request. The API requires an Origin it
    * recognises on every data request and answers 403 without one, so every
    * caller was setting it by hand on each `send`; this does it once.
+   *
+   * Falls back to `LOCATION_ORIGIN` / `LOCATION_SERVICE_ORIGIN`, so the
+   * zero-argument connector can be made to work from the environment alone.
    */
   origin?: string
 }
 
 export interface SendOptions extends RequestOptions {
   headers?: Record<string, string>
+}
+
+/** Where this connector's tokens come from, whichever way it was configured. */
+interface TokenSource {
+  /**
+   * Resolved when a request is about to be sent, NOT when the source is built —
+   * `getAppConfig` reads claims off the token and needs no URL at all, and used
+   * to fail on a connector configured with a bare `token` because this was
+   * demanded up front.
+   */
+  apiUrl(): string
+  /**
+   * `forceRefresh` asks for a replacement rather than the cached token. A
+   * source with nothing to refresh answers with the same one, which is exactly
+   * what the retry guard in `dispatchWithRetry` reads.
+   */
+  get(forceRefresh?: boolean): Promise<string | undefined>
+}
+
+/** Header lookup that does not care how the caller capitalised the name. */
+function headerValue(
+  headers: Record<string, string> | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) return undefined
+  const wanted = name.toLowerCase()
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === wanted) return value
+  }
+  return undefined
+}
+
+/**
+ * The headers `dispatch` sets itself, and which a caller therefore cannot
+ * supply. Lower-case, because that is how they are compared.
+ *
+ * Kept beside `withoutHeaders` so the list and the record in `dispatch` cannot
+ * drift apart: a header added there must be added here too, or the caller's own
+ * spelling of it survives the merge.
+ */
+const SYSTEM_HEADERS = ['origin', 'content-type', 'authorization']
+
+/** The caller's headers minus `names`, however they capitalised them. */
+function withoutHeaders(
+  headers: Record<string, string> | undefined,
+  names: string[],
+): Record<string, string> {
+  if (!headers) return {}
+  const wanted = new Set(names)
+  return Object.fromEntries(
+    Object.entries(headers).filter(([key]) => !wanted.has(key.toLowerCase())),
+  )
+}
+
+/**
+ * Say why the 403 happened, when we know.
+ *
+ * `Origin not allowed` with no Origin sent is not an ambiguous failure — it is
+ * the documented backend path missing one piece of configuration (#45), and the
+ * API's own message cannot say so because from its side the header is simply
+ * absent. A new integrator following the README hit a bare "Origin not allowed"
+ * that named neither the cause nor the fix.
+ */
+function explainMissingOrigin(
+  err: unknown,
+  sentOrigin: string | undefined,
+): unknown {
+  if (sentOrigin) return err
+  if (!(err instanceof LocationServiceException)) return err
+  if (err.code !== 'OriginNotAllowedException') return err
+
+  return new LocationServiceException({
+    code: err.code,
+    message:
+      `${err.message} — this request carried no Origin header, and the API requires ` +
+      `one it recognises on every data request. Set \`origin\` on the ` +
+      `LocationServiceConnector, set LOCATION_ORIGIN, or pass an Origin in the ` +
+      `per-call headers; if the application has no allowed domain configured in ` +
+      `the developer portal yet, set that first.`,
+    statusCode: err.statusCode,
+    requestId: err.requestId,
+    details: err.details,
+    cause: err,
+  })
 }
 
 /**
@@ -35,31 +141,87 @@ export interface SendOptions extends RequestOptions {
  * token management, and the same transport (timeout, cancellation, retry) as the
  * browser client.
  *
+ * Configuration is COMPLETED from the environment rather than replaced by it.
+ * The constructor used to be all-or-nothing — any argument at all took the
+ * "caller supplies everything" branch — so `new LocationServiceConnector()` had
+ * credentials but could never send an Origin (403 on every data request) and
+ * `new LocationServiceConnector({ origin })` had an Origin but no credentials
+ * (#45). Now an explicit `token`/`getToken` still wins outright, and anything
+ * short of that is filled in from `LOCATION_API_URL` / `LOCATION_CLIENT_ID` /
+ * `LOCATION_CLIENT_SECRET` / `LOCATION_ORIGIN`.
+ *
  * @example
  * ```typescript
+ * // Credentials and apiUrl from the environment, Origin supplied here
  * const connector = new LocationServiceConnector({ origin: 'https://app.example.com' })
  * const result = await connector.send(new SearchTextCommand({ QueryText: 'Space Needle' }))
  * ```
  */
 export class LocationServiceConnector {
-  private configPromise: Promise<ServerClientConfig | ConnectorConfig>
-  private origin?: string
+  private readonly config: ConnectorConfig
+  private tokenSource?: TokenSource
+  private readonly origin?: string
   public readonly serviceId: string = 'Geo Places'
 
-  constructor(config?: ConnectorConfig) {
-    this.configPromise = config ? Promise.resolve(config) : getClientConfig()
-    this.origin = config?.origin
+  constructor(config: ConnectorConfig = {}) {
+    this.config = config
+    // `||`, not `??`, to match the other four env-completed fields: an empty
+    // string is not a choice to send no Origin, it is a missing value, and the
+    // asymmetry meant `origin: ''` suppressed the environment and then produced
+    // an error telling the caller to set a variable they may already have set.
+    this.origin =
+      config.origin ||
+      process.env.LOCATION_ORIGIN ||
+      process.env.LOCATION_SERVICE_ORIGIN
   }
 
-  /** One place that knows how a token is obtained, so nothing can drift. */
-  private async resolveToken(): Promise<string | undefined> {
-    const config = await this.configPromise
-    if ('getToken' in config && typeof config.getToken === 'function') {
-      const result = await config.getToken()
-      if (!result) return undefined
-      return typeof result === 'string' ? result : result.token
+  /**
+   * One place that knows how a token is obtained, so nothing can drift.
+   *
+   * Built on first use rather than in the constructor: resolving the
+   * environment path used to start a `/auth/token` round trip from `new`, whose
+   * rejection nothing was awaiting yet — an unhandled rejection for a
+   * misconfigured process, before it had made a single request.
+   */
+  private source(): TokenSource {
+    return (this.tokenSource ??= this.buildSource())
+  }
+
+  private buildSource(): TokenSource {
+    const { apiUrl, token, getToken, clientId, clientSecret } = this.config
+
+    // An explicit token source wins outright. A caller that supplied one is
+    // managing credentials itself, and quietly reading the environment
+    // underneath it could send another application's token.
+    if (getToken) {
+      return {
+        apiUrl: () => requireApiUrl(apiUrl),
+        get: async (forceRefresh) => {
+          const result = await getToken(forceRefresh)
+          if (!result) return undefined
+          return typeof result === 'string' ? result : result.token
+        },
+      }
     }
-    return (config as ConnectorConfig).token
+
+    if (token) {
+      return {
+        apiUrl: () => requireApiUrl(apiUrl),
+        // A fixed string. Asking again returns the same one, which is how the
+        // retry guard knows there is nothing to retry with.
+        get: async () => token,
+      }
+    }
+
+    // Nothing but (at most) an apiUrl and an origin — complete it from the
+    // environment. This is the branch every sample and doc actually takes.
+    const env = serverTokenSource({ apiUrl, clientId, clientSecret })
+    return {
+      // Already validated by serverTokenSource, which cannot resolve
+      // credentials without it.
+      apiUrl: () => env.apiUrl,
+      get: async (forceRefresh) => (await env.getToken(forceRefresh)).token,
+    }
   }
 
   /**
@@ -77,48 +239,130 @@ export class LocationServiceConnector {
    * case until one is configured in the portal.
    */
   async getAppConfig(): Promise<AppConfigClaims> {
-    return readAppConfigClaims(await this.resolveToken())
+    return readAppConfigClaims(await this.source().get())
+  }
+
+  /**
+   * The Origin this request will actually carry.
+   *
+   * ONE definition, for the two readers that must never disagree about it: the
+   * header merge in `dispatch`, and the 403 explanation in `send`. A per-call
+   * header beats the connector default, whatever the caller capitalised.
+   */
+  private effectiveOrigin(options?: SendOptions): string | undefined {
+    // `||` for the same reason as the constructor: an empty per-call header is
+    // a missing value, not a decision to send no Origin.
+    return headerValue(options?.headers, 'origin') || this.origin
   }
 
   async send<TInput, TOutput>(
     command: TInput,
     options?: SendOptions,
   ): Promise<TOutput> {
-    const token = await this.resolveToken()
-
-    if (!token) {
-      throw new LocationServiceException({
-        code: 'InvalidCredentialsException',
-        message:
-          'No token available — check clientId/clientSecret configuration',
-        details: { source: 'client' },
-      })
-    }
-
+    const source = this.source()
     const cmd = command as unknown as GeoPlacesCommand
-    const endpoint = resolveEndpoint(cmd)
+    const url = `${source.apiUrl()}${resolveEndpoint(cmd)}`
 
-    // The token is already resolved above, so the precision this application
-    // is entitled to is available before the request is shaped (api#65).
-    // Absent claim -> the 3 dp floor, which is what every application gets
-    // until one is configured otherwise.
+    try {
+      return await this.dispatchWithRetry<TOutput>(source, url, cmd, options)
+    } catch (err) {
+      throw explainMissingOrigin(err, this.effectiveOrigin(options))
+    }
+  }
+
+  private async dispatchWithRetry<TOutput>(
+    source: TokenSource,
+    url: string,
+    cmd: GeoPlacesCommand,
+    options?: SendOptions,
+  ): Promise<TOutput> {
+    const token = await source.get()
+    if (!token) throw noTokenAvailable()
+
+    try {
+      return await this.dispatch<TOutput>(url, token, cmd, options)
+    } catch (err) {
+      if (!isTokenRejected(err)) throw err
+
+      // One retry, and only when the replacement is genuinely a different
+      // token. That single comparison covers every source: a fixed `token`
+      // string, a caller `getToken` that ignores `forceRefresh`, and a cached
+      // token the API has revoked before its `exp` all hand back what we
+      // already sent — and re-sending it would be a second doomed request, and
+      // a second billed one.
+      const fresh = await source.get(true)
+      if (!fresh || fresh === token) throw err
+
+      log('401 on a token the API no longer accepts — retrying once, refreshed')
+      return await this.dispatch<TOutput>(url, fresh, cmd, options)
+    }
+  }
+
+  private dispatch<TOutput>(
+    url: string,
+    token: string,
+    cmd: GeoPlacesCommand,
+    options?: SendOptions,
+  ): Promise<TOutput> {
+    // The token is resolved before the request is shaped, so the precision this
+    // application is entitled to is available (api#65). Absent claim -> the
+    // 3 dp floor, which is what every application gets until one is configured
+    // otherwise. Recomputed per attempt because a refreshed token may carry
+    // different claims.
     const { biasDecimals } = readAppConfigClaims(token)
     const input = roundPositionFields(cmd.input, biasDecimals)
 
-    // Caller headers first so the system ones below cannot be overridden, but an
-    // explicit per-call Origin still beats the connector-wide default.
+    // Every system header is set exactly ONCE, and the caller's own spelling of
+    // each is dropped first.
+    //
+    // Spreading them over the caller's record is not enough, because fetch's
+    // Headers fill APPENDS rather than replaces: a caller's lowercase key
+    // survives beside the canonical one and both go on the wire. For Origin
+    // that produced `Origin: default, per-call`, which the API's exact-match
+    // domain check rejects (observed: 403 OriginNotAllowedException) — and two
+    // keys with the SAME value fared no better, `Origin: x, x`. For
+    // Authorization it is worse than a failed override: `{ authorization:
+    // 'Bearer not-yours' }` went out as `Bearer not-yours, Bearer <real>`,
+    // corrupting the token rather than being ignored by it.
+    //
+    // Origin's value comes from `effectiveOrigin`, so a per-call header still
+    // beats the connector default — it is the DUPLICATE that is removed, not
+    // the caller's intent.
+    const origin = this.effectiveOrigin(options)
     const headers: Record<string, string> = {
-      ...(this.origin ? { Origin: this.origin } : {}),
-      ...(options?.headers ?? {}),
+      ...withoutHeaders(options?.headers, SYSTEM_HEADERS),
+      ...(origin ? { Origin: origin } : {}),
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     }
 
-    log('Sending %s request to %s', cmd.constructor?.name, endpoint)
+    log('Sending %s request to %s', cmd.constructor?.name, url)
     return requestJson<TOutput>(
-      `${(await this.configPromise).apiUrl}${endpoint}`,
+      url,
       { method: 'POST', headers, body: JSON.stringify(input) },
       options,
     )
   }
+}
+
+function requireApiUrl(explicit?: string): string {
+  const apiUrl = resolveApiUrl(explicit)
+  if (!apiUrl) {
+    throw new LocationServiceException({
+      code: 'ValidationException',
+      message:
+        'No API URL. Pass `apiUrl` to the LocationServiceConnector constructor ' +
+        'or set LOCATION_API_URL.',
+      details: { source: 'client' },
+    })
+  }
+  return apiUrl
+}
+
+function noTokenAvailable(): LocationServiceException {
+  return new LocationServiceException({
+    code: 'InvalidCredentialsException',
+    message: 'No token available — check clientId/clientSecret configuration',
+    details: { source: 'client' },
+  })
 }

--- a/src/server/getClientConfig.ts
+++ b/src/server/getClientConfig.ts
@@ -1,5 +1,6 @@
 import debug from 'debug'
 import { createHash } from 'node:crypto'
+import type { TokenResponse } from '../auth/TokenProvider.js'
 import { TokenProvider } from '../auth/TokenProvider.js'
 import { LocationServiceException } from '../errors/LocationServiceException.js'
 import type { ClientConfig } from '../types/index.js'
@@ -7,6 +8,15 @@ export interface ServerAuthConfig {
   apiUrl?: string
   clientId?: string
   clientSecret?: string
+  /**
+   * Mint a new token instead of returning the cached one.
+   *
+   * For the case the cache cannot see: a token the API has stopped accepting
+   * before its `exp` — revoked in the portal, or issued against a secret that
+   * has since been rotated. `TokenProvider` judges freshness from `exp` alone,
+   * so without this a caller holding a dead token waits out its whole lifetime.
+   */
+  forceRefresh?: boolean
 }
 
 const log = debug('location-client:clientConfig')
@@ -45,6 +55,132 @@ export interface ServerClientConfig extends ClientConfig {
 }
 
 /**
+ * Where the API lives, from the argument or the environment.
+ *
+ * Separate from the credentials because the two are independently overridable:
+ * a caller can hand `LocationServiceConnector` its own `token` and still expect
+ * `LOCATION_API_URL` to say where to send it.
+ */
+export function resolveApiUrl(explicit?: string): string | undefined {
+  return (
+    explicit ||
+    process.env.LOCATION_API_URL ||
+    process.env.LOCATION_SERVICE_API_URL
+  )
+}
+
+/**
+ * A LIVE token source: resolved credentials plus a `getToken` that re-mints
+ * when the cached token is spent.
+ *
+ * This is the seam `getClientConfig` and `LocationServiceConnector` share, and
+ * it exists because the two need different SHAPES of the same thing.
+ * `getClientConfig` has to return plain data — see the warning on its return
+ * value — so it can only ever hand back a snapshot. The connector is long-lived
+ * and needs the source itself, or it dies at the first `exp` (#36).
+ *
+ * Deliberately not exported from `./server`: it hands out a callable bound to
+ * the process-wide provider, and the public surface stays the two functions
+ * that were already there.
+ */
+export interface ServerTokenSource {
+  apiUrl: string
+  /** Resolves with a token or rejects; it never resolves tokenless. */
+  getToken(forceRefresh?: boolean): Promise<TokenResponse & { token: string }>
+}
+
+export function serverTokenSource(
+  config: ServerAuthConfig = {},
+): ServerTokenSource {
+  log('[serverTokenSource] Starting with config:', {
+    hasApiUrl: !!config.apiUrl,
+    hasClientId: !!config.clientId,
+  })
+
+  // Auto-detect from environment with fallbacks
+  const apiUrl = resolveApiUrl(config.apiUrl)
+
+  const clientId =
+    config.clientId ||
+    process.env.LOCATION_CLIENT_ID ||
+    process.env.LOCATION_SERVICE_CLIENT_ID
+
+  const clientSecret =
+    config.clientSecret ||
+    process.env.LOCATION_CLIENT_SECRET ||
+    process.env.LOCATION_SERVICE_CLIENT_SECRET
+
+  log('[serverTokenSource] Resolved config:', {
+    apiUrl,
+    clientId: clientId?.substring(0, 10) + '...',
+  })
+
+  // Validate required values. A LocationServiceException like everything else
+  // this package throws — it used to be a bare `Error`, which was survivable
+  // while only `getClientConfig` could raise it and is not now that the
+  // connector reaches this path too.
+  if (!apiUrl || !clientId || !clientSecret) {
+    console.error('[location-client] Missing required configuration')
+    throw new LocationServiceException({
+      code: 'ValidationException',
+      message:
+        'Missing required configuration. Set environment variables: ' +
+        'LOCATION_API_URL, LOCATION_CLIENT_ID, LOCATION_CLIENT_SECRET',
+      details: { source: 'client' },
+    })
+  }
+
+  log('[serverTokenSource] Getting TokenProvider instance')
+  const provider = getTokenProvider(apiUrl, clientId, clientSecret)
+
+  return {
+    apiUrl,
+    async getToken(
+      forceRefresh = false,
+    ): Promise<TokenResponse & { token: string }> {
+      log('[serverTokenSource] Fetching token (forceRefresh=%s)', forceRefresh)
+      let result
+      try {
+        result = await provider.getToken(forceRefresh)
+      } catch (error) {
+        // The provider now rejects rather than resolving with success:false, and
+        // the rejection is typed — so a store outage (503) can be reported as a
+        // store outage instead of as bad credentials.
+        if (error instanceof LocationServiceException) {
+          if (error.isAuth) {
+            throw new LocationServiceException({
+              code: 'InvalidCredentialsException',
+              message:
+                `Authentication failed for client ID "${clientId}". ` +
+                `Verify LOCATION_CLIENT_ID and LOCATION_CLIENT_SECRET match your application in the developer portal.`,
+              statusCode: error.statusCode,
+              requestId: error.requestId,
+              cause: error,
+            })
+          }
+          throw error
+        }
+        throw error
+      }
+
+      // TokenProvider rejects rather than returning a tokenless success, so this
+      // is unreachable in practice — it is here to keep the contract explicit at
+      // the type level rather than asserting non-null.
+      const token = result.token
+      if (!token) {
+        throw new LocationServiceException({
+          code: 'InvalidCredentialsException',
+          message: 'Token provider returned no token',
+          details: { source: 'client' },
+        })
+      }
+
+      return { ...result, token }
+    },
+  }
+}
+
+/**
  * Get client configuration with OAuth2 authentication.
  *
  * Automatically reads from environment variables:
@@ -63,6 +199,21 @@ export interface ServerClientConfig extends ClientConfig {
  * NEVER call from browser/client code as it exposes credentials.
  * For SPA projects, create your own backend endpoint that calls this.
  *
+ * ## The return value is PLAIN DATA, and has to stay that way
+ *
+ * `{ apiUrl, token, expiresAt }` — no methods, no closures. The reason is not
+ * style: the shape every sample uses is a Next.js Server Action that returns
+ * this straight to a Client Component (every `src/lib/actions/location.ts`
+ * under `location-service-samples/web`), and the RSC boundary
+ * serialises it. A function on this object is not serialisable and throws at
+ * the boundary, so "make getClientConfig return getToken" — which #36 proposed
+ * and this JSDoc used to promise two lines below — would break every Next.js
+ * consumer of the library.
+ *
+ * A caller that needs a token which REFRESHES wants one of:
+ * - `LocationServiceConnector`, which holds a live source internally (#36), or
+ * - `TokenProvider` directly, if it is managing its own lifecycle.
+ *
  * @example
  * // Auto-detect from environment
  * const config = await getClientConfig()
@@ -70,93 +221,21 @@ export interface ServerClientConfig extends ClientConfig {
  * // Or override specific values
  * const config = await getClientConfig({ apiUrl: 'https://custom.api.com' })
  *
- * // Use getToken() for automatic caching and refresh
- * const { token } = await config.getToken()
- * const connector = new LocationServiceConnector({ apiUrl: config.apiUrl, token })
+ * // The API rejected the token before its exp — revoked, or secret rotated
+ * const fresh = await getClientConfig({ forceRefresh: true })
  */
 export async function getClientConfig(
   config: ServerAuthConfig = {},
 ): Promise<ServerClientConfig> {
-  log('[getClientConfig] Starting with config:', {
-    hasApiUrl: !!config.apiUrl,
-    hasClientId: !!config.clientId,
-  })
-
-  // Auto-detect from environment with fallbacks
-  const apiUrl =
-    config.apiUrl ||
-    process.env.LOCATION_API_URL ||
-    process.env.LOCATION_SERVICE_API_URL
-
-  const clientId =
-    config.clientId ||
-    process.env.LOCATION_CLIENT_ID ||
-    process.env.LOCATION_SERVICE_CLIENT_ID
-
-  const clientSecret =
-    config.clientSecret ||
-    process.env.LOCATION_CLIENT_SECRET ||
-    process.env.LOCATION_SERVICE_CLIENT_SECRET
-
-  log('[getClientConfig] Resolved config:', {
-    apiUrl,
-    clientId: clientId?.substring(0, 10) + '...',
-  })
-
-  // Validate required values
-  if (!apiUrl || !clientId || !clientSecret) {
-    console.error('[getClientConfig] Missing required configuration')
-    throw new Error(
-      'Missing required configuration. Set environment variables: ' +
-        'LOCATION_API_URL, LOCATION_CLIENT_ID, LOCATION_CLIENT_SECRET',
-    )
-  }
-
-  log('[getClientConfig] Getting TokenProvider instance')
-  const provider = getTokenProvider(apiUrl, clientId, clientSecret)
-
-  log('[getClientConfig] Fetching token')
-  let result
-  try {
-    result = await provider.getToken()
-  } catch (error) {
-    // The provider now rejects rather than resolving with success:false, and the
-    // rejection is typed — so a store outage (503) can be reported as a store
-    // outage instead of as bad credentials.
-    if (error instanceof LocationServiceException) {
-      if (error.isAuth) {
-        throw new LocationServiceException({
-          code: 'InvalidCredentialsException',
-          message:
-            `Authentication failed for client ID "${clientId}". ` +
-            `Verify LOCATION_CLIENT_ID and LOCATION_CLIENT_SECRET match your application in the developer portal.`,
-          statusCode: error.statusCode,
-          requestId: error.requestId,
-          cause: error,
-        })
-      }
-      throw error
-    }
-    throw error
-  }
-
-  // TokenProvider rejects rather than returning a tokenless success, so this is
-  // unreachable in practice — it is here to keep the contract explicit at the
-  // type level rather than asserting non-null.
-  if (!result.token) {
-    throw new LocationServiceException({
-      code: 'InvalidCredentialsException',
-      message: 'Token provider returned no token',
-      details: { source: 'client' },
-    })
-  }
+  const source = serverTokenSource(config)
+  const result = await source.getToken(config.forceRefresh)
 
   log(
     '[getClientConfig] Token fetched successfully, length:',
     result.token.length,
   )
   return {
-    apiUrl,
+    apiUrl: source.apiUrl,
     token: result.token,
     expiresAt: result.expiresAt,
   }

--- a/src/transport/errors.ts
+++ b/src/transport/errors.ts
@@ -92,6 +92,22 @@ function statusCode(status: number): string {
 }
 
 /**
+ * The API has rejected this token: a 401, and only a 401.
+ *
+ * The authorizer throws `Unauthorized` for a token it cannot verify or that has
+ * expired, and API Gateway turns that into a 401. Its other refusals — no
+ * domain configured for the application, an Origin the application does not
+ * allow — are a Deny policy or a service 403, and a fresh token changes
+ * neither. Retrying those would send, and bill, the same doomed request twice.
+ *
+ * Shared by both send paths so the browser client and the server connector
+ * cannot come to different conclusions about the same response.
+ */
+export function isTokenRejected(err: unknown): boolean {
+  return err instanceof LocationServiceException && err.statusCode === 401
+}
+
+/**
  * `Retry-After` is either delta-seconds or an HTTP date. Both are legal and the
  * API sends the first; a date is handled so a proxy or gateway cannot surprise us.
  */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,25 @@ export interface ClientConfig {
   /** Optional callback to get the current token dynamically. When provided,
    *  called on every request so token updates are reflected without recreating the client. */
   getToken?: () => string | undefined
+  /**
+   * Asked for a replacement AFTER the API has rejected the current token with a
+   * 401, so the request can be retried once instead of failing.
+   *
+   * Separate from `getToken` because that one is synchronous by contract — it
+   * is read while a request is being built and cannot await anything, so it can
+   * only ever return the token already in hand. Nothing in this library could
+   * therefore recover from a token revoked, or a secret rotated, before its
+   * `exp`: every request failed until the refresh buffer elapsed on its own
+   * (#36).
+   *
+   * Returning `undefined` is not "no replacement": the client then re-reads
+   * `getToken`, because a provider refreshing in the background may have landed
+   * a new token while the failed request was in flight. What actually decides
+   * is the token that comes out of those two — if it is the one just rejected,
+   * or there is none, the retry is skipped rather than repeating a request that
+   * is going to fail again.
+   */
+  refreshToken?: () => Promise<string | undefined>
 }
 
 /**

--- a/test/client-token-retry.test.ts
+++ b/test/client-token-retry.test.ts
@@ -1,0 +1,203 @@
+import { SearchTextCommand } from '@aws-sdk/client-geo-places'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GeoPlacesClient } from '../src/client/GeoPlacesClient'
+
+/**
+ * The browser client's half of #36: recovering from a token the API has stopped
+ * accepting.
+ *
+ * `getToken` is synchronous by contract — it is read while a request is being
+ * built — so it can only ever hand back the token already in hand. That left
+ * nothing in this library able to recover from a token revoked, or a secret
+ * rotated, before its `exp`: every request 401'd until the 60 s refresh buffer
+ * elapsed on its own. `refreshToken` is the async escape hatch, and the guard
+ * that matters is the one that DOESN'T retry, because a repeat of a doomed
+ * request is a second billed request.
+ */
+
+const API = 'https://api.test'
+
+const ok = () =>
+  new Response(JSON.stringify({ ResultItems: [] }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+
+const unauthorized = () =>
+  new Response(JSON.stringify({ message: 'Unauthorized' }), {
+    status: 401,
+    headers: { 'content-type': 'application/json' },
+  })
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+const authHeaders = () =>
+  fetchMock.mock.calls.map(([, init]) => init.headers.Authorization)
+
+/** 401 first, then 200 — the shape of a token replaced mid-session. */
+const rejectThenAccept = () => {
+  let seen = 0
+  fetchMock.mockImplementation(async () => {
+    seen += 1
+    return seen === 1 ? unauthorized() : ok()
+  })
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockImplementation(async () => ok())
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('a 401 is retried once when a replacement token exists (#36)', () => {
+  it('asks refreshToken and retries with what it returns', async () => {
+    rejectThenAccept()
+    const refreshToken = vi.fn().mockResolvedValue('fresh')
+    const client = new GeoPlacesClient({
+      apiUrl: API,
+      token: 'stale',
+      refreshToken,
+    })
+
+    await expect(
+      client.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).resolves.toEqual({ ResultItems: [] })
+
+    expect(refreshToken).toHaveBeenCalledTimes(1)
+    expect(authHeaders()).toEqual(['Bearer stale', 'Bearer fresh'])
+  })
+
+  it('falls back to re-reading getToken, for a background refresh that landed', async () => {
+    let current = 'stale'
+    const client = new GeoPlacesClient({
+      apiUrl: API,
+      token: 'unused',
+      getToken: () => current,
+    })
+
+    // What the React provider does: reading a stale token starts a refresh in
+    // the background, so by the time the 401 comes back the new one is there.
+    fetchMock.mockImplementationOnce(async () => {
+      current = 'fresh'
+      return unauthorized()
+    })
+
+    await client.send(new SearchTextCommand({ QueryText: 'x' }))
+
+    expect(authHeaders()).toEqual(['Bearer stale', 'Bearer fresh'])
+  })
+
+  it('retries at most once', async () => {
+    fetchMock.mockImplementation(async () => unauthorized())
+    let n = 0
+    const client = new GeoPlacesClient({
+      apiUrl: API,
+      token: 'stale',
+      refreshToken: async () => `fresh-${++n}`,
+    })
+
+    await expect(
+      client.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).rejects.toMatchObject({ statusCode: 401 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('and NOT retried when there is nothing new to send', () => {
+  it('does not retry without a refreshToken and a static token', async () => {
+    fetchMock.mockImplementation(async () => unauthorized())
+    const client = new GeoPlacesClient({ apiUrl: API, token: 'stale' })
+
+    await expect(
+      client.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).rejects.toMatchObject({ statusCode: 401 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry when refreshToken returns the same token', async () => {
+    fetchMock.mockImplementation(async () => unauthorized())
+    const client = new GeoPlacesClient({
+      apiUrl: API,
+      token: 'stale',
+      refreshToken: async () => 'stale',
+    })
+
+    await expect(
+      client.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).rejects.toMatchObject({ statusCode: 401 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry when refreshToken returns nothing', async () => {
+    fetchMock.mockImplementation(async () => unauthorized())
+    const client = new GeoPlacesClient({
+      apiUrl: API,
+      token: 'stale',
+      refreshToken: async () => undefined,
+    })
+
+    await expect(
+      client.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).rejects.toMatchObject({ statusCode: 401 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry a 403 — a fresh token cannot fix an Origin or a Deny', async () => {
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            message: 'Origin not allowed',
+            code: 'OriginNotAllowedException',
+          }),
+          { status: 403, headers: { 'content-type': 'application/json' } },
+        ),
+    )
+    const client = new GeoPlacesClient({
+      apiUrl: API,
+      token: 'stale',
+      refreshToken: async () => 'fresh',
+    })
+
+    await expect(
+      client.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).rejects.toMatchObject({ code: 'OriginNotAllowedException' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-rounds the bias for the replacement token, whose claims may differ', async () => {
+    // biasDecimals is a claim ON the token, and the request body is shaped from
+    // it. A retry that reused the first attempt's body would send the old
+    // application's precision — a silent cache split, not an error.
+    const jwt = (claims: Record<string, unknown>) => {
+      const b64 = (o: unknown) =>
+        Buffer.from(JSON.stringify(o)).toString('base64url')
+      return `${b64({ alg: 'HS256' })}.${b64(claims)}.s`
+    }
+    rejectThenAccept()
+    const client = new GeoPlacesClient({
+      apiUrl: API,
+      token: jwt({ biasDecimals: 3 }),
+      refreshToken: async () => jwt({ biasDecimals: 5 }),
+    })
+
+    await client.send(
+      new SearchTextCommand({
+        QueryText: 'x',
+        BiasPosition: [151.21536789, -33.85681234],
+      }),
+    )
+
+    const bodies = fetchMock.mock.calls.map(([, init]) => JSON.parse(init.body))
+    expect(bodies[0].BiasPosition).toEqual([151.215, -33.857])
+    expect(bodies[1].BiasPosition).toEqual([151.21537, -33.85681])
+  })
+})

--- a/test/connector.test.ts
+++ b/test/connector.test.ts
@@ -26,19 +26,105 @@ const ok = () =>
     headers: { 'content-type': 'application/json' },
   })
 
+/**
+ * Every environment variable the server surface reads. Cleared for every test:
+ * the connector now COMPLETES its configuration from the environment (#45), so
+ * a developer's own LOCATION_API_URL would otherwise silently change what these
+ * tests exercise.
+ */
+const ENV_KEYS = [
+  'LOCATION_API_URL',
+  'LOCATION_SERVICE_API_URL',
+  'LOCATION_CLIENT_ID',
+  'LOCATION_SERVICE_CLIENT_ID',
+  'LOCATION_CLIENT_SECRET',
+  'LOCATION_SERVICE_CLIENT_SECRET',
+  'LOCATION_ORIGIN',
+  'LOCATION_SERVICE_ORIGIN',
+]
+
 let fetchMock: ReturnType<typeof vi.fn>
+let saved: Record<string, string | undefined>
+/** Every token `/auth/token` has handed out this test, in order. */
+let issued: string[]
 
 const sent = () => {
   const [url, init] = fetchMock.mock.calls[0]
   return { url, init, body: JSON.parse(init.body) }
 }
 
+/** The data requests only — the env path spends call 0 on `/auth/token`. */
+const dataCalls = () =>
+  fetchMock.mock.calls.filter(
+    ([url]: [string]) => !String(url).endsWith('/auth/token'),
+  )
+
+const tokenCalls = () =>
+  fetchMock.mock.calls.filter(([url]: [string]) =>
+    String(url).endsWith('/auth/token'),
+  )
+
+const lastData = () => {
+  const calls = dataCalls()
+  const [url, init] = calls[calls.length - 1]!
+  return { url, init, body: JSON.parse(init.body) }
+}
+
+const mintedToken = () => {
+  issued.push(jwt({ seq: issued.length + 1 }))
+  return new Response(JSON.stringify({ access_token: issued.at(-1) }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+const apiError = (status: number, body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+
+/**
+ * A fresh module graph, because `serverTokenSource` reaches a PROCESS-WIDE
+ * TokenProvider singleton. Without the reset, one test's cached token is handed
+ * to the next and the refresh assertions all pass for the wrong reason.
+ *
+ * The exception class is imported from the same graph deliberately —
+ * `vi.resetModules` rebuilds it, and `instanceof` compares identity.
+ */
+const load = async () => {
+  vi.resetModules()
+  const [{ LocationServiceConnector }, { LocationServiceException }] =
+    await Promise.all([
+      import('../src/server/LocationServiceConnector'),
+      import('../src/errors/LocationServiceException'),
+    ])
+  return { LocationServiceConnector, LocationServiceException }
+}
+
+const withEnvCredentials = () => {
+  process.env.LOCATION_API_URL = 'https://env.test'
+  process.env.LOCATION_CLIENT_ID = 'env-id'
+  process.env.LOCATION_CLIENT_SECRET = 'env-secret'
+}
+
 beforeEach(() => {
-  fetchMock = vi.fn().mockImplementation(async () => ok())
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]))
+  for (const k of ENV_KEYS) delete process.env[k]
+  issued = []
+  fetchMock = vi
+    .fn()
+    .mockImplementation(async (url: string) =>
+      String(url).endsWith('/auth/token') ? mintedToken() : ok(),
+    )
   vi.stubGlobal('fetch', fetchMock)
 })
 
 afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
   vi.unstubAllGlobals()
 })
 
@@ -87,6 +173,33 @@ describe('the request it builds', () => {
     expect(sent().init.headers.Authorization).toBe(`Bearer ${token}`)
   })
 
+  it.each(['authorization', 'AUTHORIZATION'])(
+    'does not let a caller %s CORRUPT the token either',
+    async (header) => {
+      // Spreading the system headers last only out-ranks the caller's key when
+      // it is spelled identically. A case variant survived beside it, and
+      // fetch's Headers fill appends — so `Bearer not-yours` was not ignored,
+      // it was prepended: `Bearer not-yours, Bearer <real>`.
+      const token = jwt()
+      await connector({ token }).send(
+        new SearchTextCommand({ QueryText: 'x' }),
+        { headers: { [header]: 'Bearer not-yours' } },
+      )
+      expect(new Headers(sent().init.headers).get('authorization')).toBe(
+        `Bearer ${token}`,
+      )
+    },
+  )
+
+  it('does not let a caller content-type corrupt the JSON body header', async () => {
+    await connector().send(new SearchTextCommand({ QueryText: 'x' }), {
+      headers: { 'content-type': 'text/plain' },
+    })
+    expect(new Headers(sent().init.headers).get('content-type')).toBe(
+      'application/json',
+    )
+  })
+
   it('omits Origin entirely when none is configured', async () => {
     await connector().send(new SearchTextCommand({ QueryText: 'x' }))
     expect(sent().init.headers.Origin).toBeUndefined()
@@ -124,6 +237,9 @@ describe('bias precision comes from the token (api#65)', () => {
 
 describe('when there is no token', () => {
   it('refuses with advice rather than sending Bearer undefined', async () => {
+    // `token: undefined` is no longer "the caller supplied a token" — since #45
+    // a partial config is COMPLETED from the environment, and there is nothing
+    // there either. Either way nothing is sent.
     const c = new LocationServiceConnector({
       apiUrl: 'https://api.test',
       token: undefined as unknown as string,
@@ -131,8 +247,78 @@ describe('when there is no token', () => {
 
     await expect(
       c.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).rejects.toMatchObject({ code: 'ValidationException' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses when a getToken callback resolves nothing', async () => {
+    const c = new LocationServiceConnector({
+      apiUrl: 'https://api.test',
+      getToken: async () => undefined,
+    })
+
+    await expect(
+      c.send(new SearchTextCommand({ QueryText: 'x' })),
     ).rejects.toMatchObject({ code: 'InvalidCredentialsException' })
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses when no apiUrl can be found anywhere', async () => {
+    const c = new LocationServiceConnector({ token: jwt() })
+
+    await expect(
+      c.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).rejects.toMatchObject({ code: 'ValidationException' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('exactly one Origin leaves, whatever the caller capitalised', () => {
+  /**
+   * `fetch` builds its Headers by APPENDING, so a record carrying both `Origin`
+   * and `origin` goes out as `Origin: a, b` — and the API matches the allowed
+   * domain exactly, so it 403s. Two keys with the same value fare no better
+   * (`Origin: x, x`). The connector therefore drops the caller's own spelling
+   * and sets the header once itself.
+   */
+
+  const originsSent = () =>
+    Object.keys(sent().init.headers).filter(
+      (key) => key.toLowerCase() === 'origin',
+    )
+
+  /** What fetch would actually put on the wire. */
+  const wireOrigin = () => new Headers(sent().init.headers).get('origin')
+
+  it.each(['Origin', 'origin', 'ORIGIN'])(
+    'lets a per-call %s beat the connector default, once',
+    async (header) => {
+      await connector({ origin: 'https://default.example' }).send(
+        new SearchTextCommand({ QueryText: 'x' }),
+        { headers: { [header]: 'https://per-call.example' } },
+      )
+
+      expect(originsSent()).toHaveLength(1)
+      expect(wireOrigin()).toBe('https://per-call.example')
+    },
+  )
+
+  it('does not double a per-call Origin that repeats the default', async () => {
+    await connector({ origin: 'https://same.example' }).send(
+      new SearchTextCommand({ QueryText: 'x' }),
+      { headers: { origin: 'https://same.example' } },
+    )
+
+    expect(wireOrigin()).toBe('https://same.example')
+  })
+
+  it('keeps every other caller header untouched', async () => {
+    await connector({ origin: 'https://default.example' }).send(
+      new SearchTextCommand({ QueryText: 'x' }),
+      { headers: { origin: 'https://per-call.example', 'X-Trace': 'abc' } },
+    )
+
+    expect(sent().init.headers['X-Trace']).toBe('abc')
   })
 })
 
@@ -150,6 +336,16 @@ describe('getAppConfig reads the token, not the API', () => {
 
   it('returns {} when the token carries no application config', async () => {
     await expect(connector().getAppConfig()).resolves.toEqual({})
+  })
+
+  it('needs no apiUrl, because it reads claims rather than sending anything', async () => {
+    // The URL is resolved when a request is about to go out, not when the token
+    // source is built — demanding it up front made this throw on a connector
+    // configured with nothing but a token.
+    const c = new LocationServiceConnector({ token: jwt({ biasDecimals: 4 }) })
+
+    await expect(c.getAppConfig()).resolves.toEqual({ biasDecimals: 4 })
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })
 
@@ -177,5 +373,456 @@ describe('a getToken callback is supported alongside a static token', () => {
 
     await c.send(new SearchTextCommand({ QueryText: 'x' }))
     expect(sent().init.headers.Authorization).toBe(`Bearer ${token}`)
+  })
+})
+
+describe('configuration is COMPLETED from the environment, not replaced (#45)', () => {
+  /**
+   * The constructor used to be all-or-nothing: `config ? Promise.resolve(config)
+   * : getClientConfig()`. So the zero-argument form documented everywhere had
+   * credentials and could never send an Origin (403 on every data request), and
+   * `{ origin }` — the obvious repair — took the other branch and had no
+   * credentials at all. Neither form could make a successful data call.
+   */
+
+  it('takes credentials AND an origin, which no single form could before', async () => {
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector({ origin: 'https://app.example' }).send(
+      new SearchTextCommand({ QueryText: 'x' }),
+    )
+
+    expect(tokenCalls()).toHaveLength(1)
+    expect(lastData().url).toBe('https://env.test/address/search/text')
+    expect(lastData().init.headers.Origin).toBe('https://app.example')
+    expect(lastData().init.headers.Authorization).toBe(`Bearer ${issued[0]}`)
+  })
+
+  it('reads the Origin from LOCATION_ORIGIN, so the zero-arg form works', async () => {
+    withEnvCredentials()
+    process.env.LOCATION_ORIGIN = 'https://from-env.example'
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector().send(
+      new SearchTextCommand({ QueryText: 'x' }),
+    )
+
+    expect(lastData().init.headers.Origin).toBe('https://from-env.example')
+  })
+
+  it('accepts the LOCATION_SERVICE_ORIGIN spelling too', async () => {
+    // The fourth member of the LOCATION_SERVICE_* family; the other three are
+    // proven in test/get-client-config.test.ts.
+    withEnvCredentials()
+    process.env.LOCATION_SERVICE_ORIGIN = 'https://alt-spelling.example'
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector().send(
+      new SearchTextCommand({ QueryText: 'x' }),
+    )
+
+    expect(lastData().init.headers.Origin).toBe('https://alt-spelling.example')
+  })
+
+  it('prefers LOCATION_ORIGIN over the LOCATION_SERVICE_ spelling', async () => {
+    withEnvCredentials()
+    process.env.LOCATION_ORIGIN = 'https://primary.example'
+    process.env.LOCATION_SERVICE_ORIGIN = 'https://alt-spelling.example'
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector().send(
+      new SearchTextCommand({ QueryText: 'x' }),
+    )
+
+    expect(lastData().init.headers.Origin).toBe('https://primary.example')
+  })
+
+  it('takes credentials from the CONFIG when the environment has none', async () => {
+    // ConnectorConfig carries clientId/clientSecret so the merge story is
+    // "complete it from wherever", not "everything but the credentials".
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector({
+      apiUrl: 'https://api.test',
+      clientId: 'config-id',
+      clientSecret: 'config-secret',
+      origin: 'https://app.example',
+    }).send(new SearchTextCommand({ QueryText: 'x' }))
+
+    expect(tokenCalls()).toHaveLength(1)
+    expect(tokenCalls()[0]![0]).toBe('https://api.test/auth/token')
+    // Basic base64("config-id:config-secret")
+    expect(tokenCalls()[0]![1].headers.Authorization).toBe(
+      `Basic ${Buffer.from('config-id:config-secret').toString('base64')}`,
+    )
+    expect(lastData().init.headers.Authorization).toBe(`Bearer ${issued[0]}`)
+  })
+
+  it('lets config credentials beat the environment', async () => {
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector({
+      clientId: 'config-id',
+      clientSecret: 'config-secret',
+      origin: 'https://app.example',
+    }).send(new SearchTextCommand({ QueryText: 'x' }))
+
+    expect(tokenCalls()[0]![1].headers.Authorization).toBe(
+      `Basic ${Buffer.from('config-id:config-secret').toString('base64')}`,
+    )
+  })
+
+  it('treats an empty constructor origin as missing, not as a choice', async () => {
+    // `origin: ''` used to suppress the environment and then produce an error
+    // advising the caller to set LOCATION_ORIGIN — which they had set.
+    withEnvCredentials()
+    process.env.LOCATION_ORIGIN = 'https://from-env.example'
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector({ origin: '' }).send(
+      new SearchTextCommand({ QueryText: 'x' }),
+    )
+
+    expect(lastData().init.headers.Origin).toBe('https://from-env.example')
+  })
+
+  it('treats an empty per-call origin as missing too', async () => {
+    withEnvCredentials()
+    process.env.LOCATION_ORIGIN = 'https://from-env.example'
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector().send(
+      new SearchTextCommand({ QueryText: 'x' }),
+      { headers: { origin: '' } },
+    )
+
+    expect(lastData().init.headers.Origin).toBe('https://from-env.example')
+  })
+
+  it('lets an explicit origin beat LOCATION_ORIGIN', async () => {
+    withEnvCredentials()
+    process.env.LOCATION_ORIGIN = 'https://from-env.example'
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector({
+      origin: 'https://explicit.example',
+    }).send(new SearchTextCommand({ QueryText: 'x' }))
+
+    expect(lastData().init.headers.Origin).toBe('https://explicit.example')
+  })
+
+  it('takes the apiUrl from the environment when only a token is passed', async () => {
+    process.env.LOCATION_API_URL = 'https://env.test'
+    const token = jwt()
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector({ token }).send(
+      new SearchTextCommand({ QueryText: 'x' }),
+    )
+
+    expect(lastData().url).toBe('https://env.test/address/search/text')
+    expect(tokenCalls()).toHaveLength(0)
+  })
+
+  it('lets an explicit token win outright — the environment is never read', async () => {
+    // A caller managing its own credentials must not have another
+    // application's silently substituted underneath it.
+    withEnvCredentials()
+    const token = jwt({ seq: 'explicit' })
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector({
+      apiUrl: 'https://api.test',
+      token,
+    }).send(new SearchTextCommand({ QueryText: 'x' }))
+
+    expect(tokenCalls()).toHaveLength(0)
+    expect(lastData().url).toBe('https://api.test/address/search/text')
+    expect(lastData().init.headers.Authorization).toBe(`Bearer ${token}`)
+  })
+
+  it('lets an explicit getToken win outright too', async () => {
+    withEnvCredentials()
+    const token = jwt({ seq: 'callback' })
+    const { LocationServiceConnector } = await load()
+
+    await new LocationServiceConnector({
+      apiUrl: 'https://api.test',
+      getToken: async () => ({ token }),
+    }).send(new SearchTextCommand({ QueryText: 'x' }))
+
+    expect(tokenCalls()).toHaveLength(0)
+    expect(lastData().init.headers.Authorization).toBe(`Bearer ${token}`)
+  })
+
+  it('does not touch the network from the constructor', async () => {
+    // It used to: `new LocationServiceConnector()` started a /auth/token round
+    // trip nothing was awaiting yet, so a misconfigured process got an
+    // unhandled rejection before it had made a request.
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+
+    new LocationServiceConnector()
+    await Promise.resolve()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('the token refreshes, so the connector outlives its exp (#36)', () => {
+  it('mints a new token once the old one has expired', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-08-31T00:00:00Z'))
+      withEnvCredentials()
+      const { LocationServiceConnector } = await load()
+      const c = new LocationServiceConnector({ origin: 'https://app.example' })
+
+      await c.send(new SearchTextCommand({ QueryText: 'first' }))
+      expect(lastData().init.headers.Authorization).toBe(`Bearer ${issued[0]}`)
+
+      // Past the 900 s exp of the token minted above.
+      vi.setSystemTime(Date.now() + 901_000)
+      await c.send(new SearchTextCommand({ QueryText: 'second' }))
+
+      expect(tokenCalls()).toHaveLength(2)
+      expect(issued[1]).not.toBe(issued[0])
+      expect(lastData().init.headers.Authorization).toBe(`Bearer ${issued[1]}`)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reuses the cached token while it is still good', async () => {
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+    const c = new LocationServiceConnector({ origin: 'https://app.example' })
+
+    await c.send(new SearchTextCommand({ QueryText: 'a' }))
+    await c.send(new SearchTextCommand({ QueryText: 'b' }))
+
+    expect(tokenCalls()).toHaveLength(1)
+    expect(dataCalls()).toHaveLength(2)
+  })
+})
+
+describe('a 401 is retried exactly once, with a fresh token (#36)', () => {
+  const unauthorized = () => apiError(401, { message: 'Unauthorized' })
+
+  it('refreshes and retries when the API rejects the token', async () => {
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+    let dataSeen = 0
+    fetchMock.mockImplementation(async (url: string) => {
+      if (String(url).endsWith('/auth/token')) return mintedToken()
+      dataSeen += 1
+      return dataSeen === 1 ? unauthorized() : ok()
+    })
+
+    const c = new LocationServiceConnector({ origin: 'https://app.example' })
+    await expect(
+      c.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).resolves.toEqual({ ResultItems: [] })
+
+    expect(dataCalls()).toHaveLength(2)
+    expect(dataCalls()[0]![1].headers.Authorization).toBe(`Bearer ${issued[0]}`)
+    expect(dataCalls()[1]![1].headers.Authorization).toBe(`Bearer ${issued[1]}`)
+  })
+
+  it('gives up after one retry rather than looping', async () => {
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/auth/token') ? mintedToken() : unauthorized(),
+    )
+
+    const c = new LocationServiceConnector({ origin: 'https://app.example' })
+    await expect(
+      c.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).rejects.toMatchObject({ statusCode: 401 })
+
+    expect(dataCalls()).toHaveLength(2)
+  })
+
+  it('does NOT retry a static token — the second request would be identical', async () => {
+    // And billed. A fixed string cannot be refreshed, so there is nothing to
+    // retry WITH.
+    const { LocationServiceConnector } = await load()
+    fetchMock.mockImplementation(async () => unauthorized())
+
+    await expect(
+      new LocationServiceConnector({
+        apiUrl: 'https://api.test',
+        token: jwt(),
+      }).send(new SearchTextCommand({ QueryText: 'x' })),
+    ).rejects.toMatchObject({ statusCode: 401 })
+
+    expect(dataCalls()).toHaveLength(1)
+  })
+
+  it('does NOT retry when the refresh hands back the same token', async () => {
+    const token = jwt()
+    const { LocationServiceConnector } = await load()
+    fetchMock.mockImplementation(async () => unauthorized())
+
+    await expect(
+      new LocationServiceConnector({
+        apiUrl: 'https://api.test',
+        getToken: async () => ({ token }),
+      }).send(new SearchTextCommand({ QueryText: 'x' })),
+    ).rejects.toMatchObject({ statusCode: 401 })
+
+    expect(dataCalls()).toHaveLength(1)
+  })
+
+  it('passes forceRefresh:true to a caller getToken, and uses what comes back', async () => {
+    const stale = jwt({ seq: 'stale' })
+    const fresh = jwt({ seq: 'fresh' })
+    const getToken = vi.fn(async (forceRefresh?: boolean) => ({
+      token: forceRefresh ? fresh : stale,
+    }))
+    const { LocationServiceConnector } = await load()
+    let dataSeen = 0
+    fetchMock.mockImplementation(async () => {
+      dataSeen += 1
+      return dataSeen === 1 ? unauthorized() : ok()
+    })
+
+    await new LocationServiceConnector({
+      apiUrl: 'https://api.test',
+      getToken,
+    }).send(new SearchTextCommand({ QueryText: 'x' }))
+
+    expect(getToken).toHaveBeenNthCalledWith(2, true)
+    expect(dataCalls()[1]![1].headers.Authorization).toBe(`Bearer ${fresh}`)
+  })
+
+  it('re-rounds the bias for the replacement token, whose claims may differ', async () => {
+    // biasDecimals is a claim ON the token and the body is shaped from it, so a
+    // retry reusing the first attempt's body would send the old precision — a
+    // silent cache split, not an error. Mirrors the browser-path test in
+    // test/client-token-retry.test.ts.
+    const { LocationServiceConnector } = await load()
+    let dataSeen = 0
+    fetchMock.mockImplementation(async () => {
+      dataSeen += 1
+      return dataSeen === 1 ? unauthorized() : ok()
+    })
+
+    await new LocationServiceConnector({
+      apiUrl: 'https://api.test',
+      getToken: async (forceRefresh) => ({
+        token: jwt({ biasDecimals: forceRefresh ? 5 : 3 }),
+      }),
+    }).send(
+      new SearchTextCommand({
+        QueryText: 'x',
+        BiasPosition: [151.21536789, -33.85681234],
+      }),
+    )
+
+    const bodies = dataCalls().map(([, init]) => JSON.parse(init.body))
+    expect(bodies[0].BiasPosition).toEqual([151.215, -33.857])
+    expect(bodies[1].BiasPosition).toEqual([151.21537, -33.85681])
+  })
+
+  it('does NOT retry a 403 — a new token cannot fix an Origin or a Deny', async () => {
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/auth/token')
+        ? mintedToken()
+        : apiError(403, {
+            message: 'Origin not allowed',
+            code: 'OriginNotAllowedException',
+          }),
+    )
+
+    await expect(
+      new LocationServiceConnector({ origin: 'https://app.example' }).send(
+        new SearchTextCommand({ QueryText: 'x' }),
+      ),
+    ).rejects.toMatchObject({ code: 'OriginNotAllowedException' })
+
+    expect(dataCalls()).toHaveLength(1)
+  })
+})
+
+describe('a 403 on a request that carried no Origin says so (#45)', () => {
+  const originDenied = () =>
+    apiError(403, {
+      message: 'Origin not allowed',
+      code: 'OriginNotAllowedException',
+    })
+
+  it('names the missing header and how to supply it', async () => {
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/auth/token') ? mintedToken() : originDenied(),
+    )
+
+    const err = await new LocationServiceConnector()
+      .send(new SearchTextCommand({ QueryText: 'x' }))
+      .catch((e) => e)
+
+    expect(err.code).toBe('OriginNotAllowedException')
+    expect(err.statusCode).toBe(403)
+    // The API's own message survives; the advice is appended to it.
+    expect(err.message).toContain('Origin not allowed')
+    expect(err.message).toContain('carried no Origin header')
+    expect(err.message).toContain('LOCATION_ORIGIN')
+  })
+
+  it('leaves the API message alone when an Origin WAS sent', async () => {
+    // Then the Origin is wrong, not missing, and telling the caller to set one
+    // sends them looking in the wrong place.
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/auth/token') ? mintedToken() : originDenied(),
+    )
+
+    const err = await new LocationServiceConnector({
+      origin: 'https://wrong.example',
+    })
+      .send(new SearchTextCommand({ QueryText: 'x' }))
+      .catch((e) => e)
+
+    expect(err.message).toBe('Origin not allowed')
+  })
+
+  it('counts a per-call Origin as sent, whatever its capitalisation', async () => {
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/auth/token') ? mintedToken() : originDenied(),
+    )
+
+    const err = await new LocationServiceConnector()
+      .send(new SearchTextCommand({ QueryText: 'x' }), {
+        headers: { origin: 'https://per-call.example' },
+      })
+      .catch((e) => e)
+
+    expect(err.message).toBe('Origin not allowed')
+  })
+
+  it('leaves an unrelated 403 alone', async () => {
+    withEnvCredentials()
+    const { LocationServiceConnector } = await load()
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/auth/token')
+        ? mintedToken()
+        : apiError(403, { message: 'Forbidden' }),
+    )
+
+    const err = await new LocationServiceConnector()
+      .send(new SearchTextCommand({ QueryText: 'x' }))
+      .catch((e) => e)
+
+    expect(err.message).toBe('Forbidden')
   })
 })

--- a/test/get-client-config.test.ts
+++ b/test/get-client-config.test.ts
@@ -257,3 +257,72 @@ describe('what it returns', () => {
     expect(JSON.stringify(cfg)).not.toContain('super-secret-value')
   })
 })
+
+describe('forceRefresh reaches past the cache (#36)', () => {
+  const withEnv = () => {
+    process.env.LOCATION_API_URL = 'https://env.test'
+    process.env.LOCATION_CLIENT_ID = 'env-id'
+    process.env.LOCATION_CLIENT_SECRET = 'env-secret'
+  }
+
+  /** Distinct tokens, so "did it re-mint" is visible in the result. */
+  const serialTokens = () => {
+    let n = 0
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: `${jwt(900).slice(0, -1)}${(n += 1)}`,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+    )
+  }
+
+  it('serves the cached token by default', async () => {
+    withEnv()
+    serialTokens()
+    const { getClientConfig } = await load()
+
+    const first = await getClientConfig()
+    const second = await getClientConfig()
+
+    expect(second.token).toBe(first.token)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('mints a new one when asked, for a token revoked before its exp', async () => {
+    // The cache judges freshness from `exp` alone, so a token revoked in the
+    // portal — or issued against a since-rotated secret — is still "fresh" to
+    // it. This is the only way past that short of restarting the process.
+    withEnv()
+    serialTokens()
+    const { getClientConfig } = await load()
+
+    const first = await getClientConfig()
+    const second = await getClientConfig({ forceRefresh: true })
+
+    expect(second.token).not.toBe(first.token)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('the return value stays plain data', () => {
+  it('carries no functions, because a Server Action has to serialise it', async () => {
+    // Every Next.js sample returns this straight out of a `'use server'` action
+    // to a Client Component, and the RSC boundary serialises it. #36 proposed
+    // adding `getToken` here; that would throw at the boundary in every one of
+    // them. The connector holds a live token source instead.
+    process.env.LOCATION_API_URL = 'https://env.test'
+    process.env.LOCATION_CLIENT_ID = 'env-id'
+    process.env.LOCATION_CLIENT_SECRET = 'env-secret'
+
+    const { getClientConfig } = await load()
+    const config = await getClientConfig()
+
+    expect(
+      Object.values(config).some((value) => typeof value === 'function'),
+    ).toBe(false)
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+})

--- a/test/maps.test.ts
+++ b/test/maps.test.ts
@@ -67,6 +67,52 @@ describe('createTransformRequest: the Accept header the API depends on', () => {
     expect(out?.headers).toBeUndefined()
   })
 
+  it('does NOT hand the token to a look-alike host (#34)', () => {
+    // `https://api.test` is a string PREFIX of `https://api.test.evil.test`,
+    // so the old startsWith gate attached Authorization here. A style
+    // descriptor is data — its sprite/glyphs/source URLs are the style
+    // author's choice — so this is reachable from any style not wholly ours.
+    const out = t(`${API}.evil.test/maps/tiles/vector.basemap/1/2/3`)
+    expect(out?.headers).toBeUndefined()
+  })
+
+  it.each([
+    ['suffixed host', `${API}.evil.test/maps/tiles/a/1/2/3`],
+    ['host as a userinfo prefix', `https://api.test@evil.test/maps/tiles/a`],
+    ['plain http', `http://api.test/maps/tiles/a/1/2/3`],
+    ['a different port', `https://api.test:8443/maps/tiles/a/1/2/3`],
+    ['a subdomain we did not name', `https://x.api.test/maps/tiles/a`],
+  ])('withholds the token from %s', (_label, url) => {
+    expect(t(url)?.headers).toBeUndefined()
+  })
+
+  it('still matches when only the URL spelling differs', () => {
+    // Same origin by the URL spec, so these are ours: the host is
+    // case-insensitive and :443 is https' default port.
+    for (const url of [
+      `https://API.TEST/maps/tiles/a/1/2/3`,
+      `https://api.test:443/maps/tiles/a/1/2/3`,
+    ]) {
+      expect(t(url)?.headers?.Authorization).toBe('Bearer tok-123')
+    }
+  })
+
+  it('honours a base path, so a co-tenant on the same host is not ours', () => {
+    const scoped = createTransformRequest('https://shared.test/v1', token)
+    expect(scoped(`https://shared.test/v1/maps/tiles/a`)?.headers).toBeDefined()
+    // A prefix of the PATH this time — the same class of bug one level down.
+    expect(
+      scoped(`https://shared.test/v1-internal/maps`)?.headers,
+    ).toBeUndefined()
+    expect(
+      scoped(`https://shared.test/v2/maps/tiles/a`)?.headers,
+    ).toBeUndefined()
+  })
+
+  it('fails closed on a URL it cannot parse', () => {
+    expect(t('not a url at all')?.headers).toBeUndefined()
+  })
+
   it('returns the url unchanged when there is no token yet', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const noToken = createTransformRequest(API, () => undefined)


### PR DESCRIPTION
Three findings from the 29 Aug client-libs + auth review, all in the same
credential path, so they ship together.

## #34 — the bearer token went to look-alike hosts

`createTransformRequest` decided whether to attach the token with
`url.startsWith(apiUrl)`. For `apiUrl = https://api.example.com` the host
`api.example.com.evil.test` is a prefix match, so a style descriptor pointing at
a look-alike host was handed `Authorization: Bearer <token>`. That is reachable
because a style descriptor is data: its `sprite`, `glyphs` and source URLs are
the style author's choice, and MapLibre asks `transformRequest` about every one.

Now compared as URLs — same origin, and the path under the API's own base path
at a `/` boundary — which also gets host case-folding and default ports right.
Fails closed on anything unparseable.

## #45 — neither documented backend form could make a data call

The constructor was `config ? Promise.resolve(config) : getClientConfig()`, so
it was all-or-nothing. `new LocationServiceConnector()` read credentials from
the environment but had no `origin`, and the API answers 403 without an `Origin`
it recognises — every data request failed. `{ origin }`, the obvious repair,
took the other branch and had no credentials at all.

Configuration is now **completed** from the environment rather than replaced by
it: an explicit `token`/`getToken` still wins outright, and anything short of
that is filled in from `LOCATION_API_URL` / `LOCATION_CLIENT_ID` /
`LOCATION_CLIENT_SECRET` and a new `LOCATION_ORIGIN`. `ConnectorConfig` also
gained `clientId`/`clientSecret` so the merge story is complete.

A 403 on a request that carried no `Origin` now says so, and says how to fix it.

## #36 — the connector died at 15 minutes, and nothing recovered from a 401

`getClientConfig` returns a static token, so the connector captured one at
construction and used it forever. It now holds a live token source internally
and refreshes; `getClientConfig({ forceRefresh })` reaches past the cache for a
token revoked before its `exp`.

Both send paths retry **once** on a 401, and only when the replacement is
genuinely a different token — a source that hands back what was just rejected
would otherwise send, and bill for, the same doomed request twice. A 403 is
never retried: a new token cannot fix an `Origin` the application does not
allow. `ClientConfig` gained an optional async `refreshToken` so the browser
client can do this too; wiring it through the React provider is
chaosity-io/location-service-client-react#19.

### One deviation from #36, deliberate

#36 asks for `getClientConfig` to return `getToken`. It does not, and must not:
every Next.js consumer returns that result straight out of a `'use server'`
action to a Client Component, and the RSC boundary serialises it — a closure on
that object throws there. The live token source went into the connector instead,
and a test now pins the return value as plain data.

## Also in here

- One `Origin`, `Content-Type` and `Authorization` header leaves per request,
  whatever the caller capitalised. `fetch` builds `Headers` by appending, so a
  caller's lowercase `origin` beside the connector's `Origin` went out as
  `Origin: a, b` (403, observed), and a lowercase `authorization` **corrupted**
  the real token rather than being ignored by it.
- `getAppConfig()` no longer demands an `apiUrl` — it reads claims off a token
  and sends nothing.
- The missing-configuration error is a `LocationServiceException` like
  everything else this package throws, not a bare `Error`.
- `AGENTS.md` gains the conventions behind all of the above; `README.md`'s
  connector section is rewritten, and its "rounded to 2 decimal places" claim
  corrected to the 3 dp default.

## Verification

Gate, on the final code: `npm ci --dry-run`, `npm run lint` (eslint +
prettier), `npm test` — **249 passing across 11 files** (was 192/10) —
`npm run build`, `npm run smoke` (186/185/3/3 exports, unchanged, so the public
surface has not moved).

Driven live against the sandbox API from a plain Node process, importing the
built `dist/`, application `XyT502`:

| case | result |
|---|---|
| zero-arg connector, no origin anywhere | 403, with the new actionable message |
| `new LocationServiceConnector({ origin })` | **200** — the form #45 reports as `InvalidCredentialsException` |
| zero-arg + `LOCATION_ORIGIN` | **200** — the form #45 reports as 403 |
| a rejected token, refreshed and retried | **200**, 2 data requests |
| a rejected token with no replacement | 401, **1** data request — no duplicate bill |
| per-call lowercase `origin` over a default | **200** |
| per-call lowercase `authorization` | **200** — token not corrupted |

A raw request carrying the doubled value `Origin: https://wrong.example,
http://localhost:3001` returns 403 `OriginNotAllowedException`, confirming the
header-merge bug was a real failure and not a theoretical one.

Every new test was watched fail: the fix was reverted, the test observed red,
then restored — 20 mutations in all. #34 could not be proven live (it is a
browser-side decision inside MapLibre and would need a look-alike host to
receive a token); it is unit-covered, and 6 of its 9 new assertions fail against
the old gate.

Reviewed by the `ship-reviewer` agent on Fable 5 before shipping.

Closes #34
Closes #36
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)
