### PR TITLE
Release v0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
Release `@chaosity/location-client` **0.7.0**.

## Why a minor, not a patch

This package is pre-1.0, so a breaking change goes in the **minor** — npm treats
each `0.x` minor as incompatible, and that is the only protection consumers get
while the API is still moving. Two behaviour changes in this release qualify:

1. `new LocationServiceConnector({ apiUrl, token: undefined })` now throws
   `ValidationException` (missing configuration, having fallen through to the
   environment-completion path) where it threw `InvalidCredentialsException`.
2. A caller-supplied `Origin` / `Authorization` / `Content-Type` header is now
   **removed** before the connector sets its own, instead of being appended
   beside it. `fetch` builds `Headers` by appending, so the old behaviour put
   `Authorization: Bearer not-yours, Bearer <real>` on the wire — a corrupted
   token rather than an ignored override. For `Origin`, a per-call value still
   wins; for the other two, the connector's value was always meant to win and
   now actually does.

## What is in it

`0a85357` — Fix the token leak and the unusable server connector (#34, #36, #45),
merged as #46:

- **#34** `createTransformRequest` attached the bearer token by string prefix, so
  a style pointing at `api.example.com.evil.test` received it. Now a URL
  comparison: same origin, path under the API's base path at a `/` boundary,
  fails closed on anything unparseable.
- **#45** `LocationServiceConnector` could not be given both credentials and an
  `Origin`, and the API answers 403 without one — neither documented backend
  form could make a data call. Configuration is now completed from the
  environment rather than replaced by it, with `LOCATION_ORIGIN` and
  `clientId`/`clientSecret` added.
- **#36** The connector captured one static token and died at its `exp`; nothing
  recovered from a 401. It now holds a live token source, `getClientConfig`
  gains `forceRefresh`, and both send paths retry once on a 401 — only when the
  replacement is genuinely a different token, since re-sending a rejected one
  bills the customer twice for the same failure. A 403 is never retried.

New optional API: `ClientConfig.refreshToken`, `ConnectorConfig.clientId` /
`clientSecret`, `ServerAuthConfig.forceRefresh`, and the `LOCATION_ORIGIN` /
`LOCATION_SERVICE_ORIGIN` environment variables. No exports were removed — the
smoke step reports the same 186/185/3/3 surface as 0.6.0.

## Dependents

None in this PR: this package is the base of the chain. `@chaosity/location-client-react`
pins `^0.6.0` as a dev dependency, which a caret cannot carry across a `0.x`
minor, so its range bump is a follow-up once 0.7.0 is on npm — and
chaosity-io/location-service-client-react#19 (wire `refreshToken` through the
provider) rides along with it.

## Verification

Run on this tree before the bump: `git status` clean on `main`, `git pull`
already up to date, `npm ci --dry-run` clean, `npm run lint` (eslint + prettier),
`npm test` — **249 passing across 11 files** — `npm run build`, `npm run smoke`
(both entry points load as ESM and CJS).

The change itself was driven live against the sandbox API from a plain Node
process importing the built `dist/`, and reviewed by the `ship-reviewer` agent
on Fable 5 before #46 was merged. Details are in #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
