### PR TITLE
Bound the whole call, and stop the token cache thrashing (#37, #39)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ working, and swaps SigV4 for this service's own bearer-token auth.
 ```bash
 npm run build       # tsc (ESM) + tsc -p tsconfig.cjs.json (CJS) + the CJS marker
 npm run dev         # tsc --watch
-npm test            # vitest run — 249 tests across 11 files
+npm test            # vitest run — 269 tests across 11 files
 npm run test:watch  # vitest interactive
 npm run smoke       # loads dist/ as ESM and as CJS — run it after build
 npm run lint        # eslint . AND prettier --check .
@@ -200,11 +200,51 @@ working around them.
   a style descriptor is data, so its sprite/glyphs/source URLs are the style
   author's choice. `createTransformRequest` compares `origin` and requires the
   path prefix at a `/` boundary, and fails closed on anything unparseable.
+- **Every outbound request goes through `transport/http.ts`.** There is exactly
+  one `fetch(` call in `src/`, inside `request()`, and that is the invariant:
+  timeout, overall budget, cancellation, retry and the single error type all
+  live there, so anything bypassing it silently opts out of all five. The two
+  map fetches did, and a network fault there escaped as a raw `TypeError` while
+  the identical fault anywhere else arrived as `NetworkException` (#37). Read
+  the body INSIDE the loop — `requestJson` and `requestBlob` pass a reader in
+  for exactly that reason — or a malformed body stops being a retryable attempt
+  and becomes a raw `SyntaxError`.
+- **`timeoutMs` bounds an attempt; `overallTimeoutMs` bounds the call.** The
+  gap between those two is where a caller's deadline used to disappear: the API
+  answers a spent quota with `Retry-After: 60`, honoured literally twice, so a
+  30-second caller waited two minutes. A wait that would outlast the remaining
+  budget is not taken at all — the API's own error is thrown instead, with
+  `retryAfterMs` on it, which is more useful to the caller than a timeout. The
+  30 s default sits just under the old worst case (three default attempts that
+  all time out came to ~30.75 s), so the overlap is a ~0.75 s window in a third
+  attempt whose two predecessors both timed out — small, but not empty, which is
+  why it went out in a minor.
+- **Nothing sends `Bearer undefined`.** Five places in `src/` interpolate a
+  token into an `Authorization` header, and every one of them checks first:
+  `GeoPlacesClient` (which asks `refreshToken` before refusing, since the 401
+  self-heal cannot cover a request that was never accepted),
+  `LocationServiceConnector`, `fetchMapStyle`, `fetchStaticMap`, and
+  `createTransformRequest` — which warns and omits the header rather than
+  throwing, because MapLibre calls it synchronously and cannot handle a throw.
+  The shared factory is `noTokenAvailable` in `transport/errors.ts`; only the
+  advice differs per path. A sixth site must join the list, not the exceptions.
+- **The server token cache is a bounded LRU, not a slot.** `getClientConfig`
+  held ONE `TokenProvider` in two module variables, so a process serving two
+  applications evicted on every alternation — a full `/auth/token` round trip
+  per call, a jti row each, against the one shared token-endpoint throttle, at a
+  0% hit rate (#39). It is now `Map<configKey, TokenProvider>` capped at
+  `MAX_CACHED_PROVIDERS`, re-inserted on a hit so insertion order IS the recency
+  order. The key still hashes the client secret (#5) — do not simplify it.
 - **A 401 is retried once; a 403 never is.** Both send paths refresh and retry
   on 401 only, and only when the replacement is genuinely a different token —
   the API's 403s (Origin not allowed, no domain configured) cannot be fixed by a
-  new token, and re-sending a doomed request bills for it twice. `isTokenRejected`
+  new token, and re-sending a doomed request sends it twice. `isTokenRejected`
   in `transport/errors.ts` is the single place that decides.
+- **An error response is not billed, whatever its status.** The service meters
+  successful requests, so a 401, a 403 or a 400 costs the caller a round trip and
+  its own deadline — not money. Worth checking before writing "and it is billed"
+  into a comment about a failure path: this file has now had that sentence wrong
+  twice, first claiming a 401 was billed and then a 403.
 - Tests are vitest and live in `test/`, not beside the source. New behaviour
   needs one; the suite is the only thing standing between a refactor and a
   silent break in a published package.

--- a/README.md
+++ b/README.md
@@ -226,8 +226,56 @@ token already in hand, and a token the API stops accepting **before** its `exp`
 the refresh buffer elapses. `refreshToken` is awaited after a 401, and the
 request is retried **once** with what it returns. Return the same token, or
 nothing, and no retry is sent — a request that is going to fail again is not
-worth being billed for twice. A 403 is never retried: a new token cannot fix an
+worth a second round trip. A 403 is never retried: a new token cannot fix an
 `Origin` the application does not allow.
+
+#### Request options
+
+Every call in this package takes the same options object — `client.send`,
+`connector.send`, `fetchMapStyle` and `fetchStaticMap` — and every failure
+arrives as a `LocationServiceException`.
+
+```typescript
+await client.send(command, {
+  signal, // AbortSignal — cancels mid-flight AND mid-backoff
+  timeoutMs: 10_000, // per ATTEMPT
+  overallTimeoutMs: 30_000, // the whole call, waits between attempts included
+  retry: { maxAttempts: 3 }, // or `false` for none
+})
+```
+
+`overallTimeoutMs` is the one worth setting deliberately, and it defaults to
+30 s. `timeoutMs` bounds an attempt, not a call: the API answers a spent quota
+with `Retry-After: 60`, and honouring that literally across two retries blocked
+the caller for about two minutes — past any Lambda budget. Now no attempt gets
+more time than the call has left, and a retry that would have to wait longer
+than the remaining budget is not made at all. You get the API's own error back
+instead, `retryAfterMs` intact, so you can queue the work rather than guess.
+
+The map helpers take them as a trailing argument:
+
+```typescript
+const style = await fetchMapStyle(
+  apiUrl,
+  'Standard',
+  getToken,
+  { language: 'fr' },
+  { signal },
+)
+const blob = await fetchStaticMap(
+  apiUrl,
+  { width: 640, height: 400, center },
+  getToken,
+  { signal },
+)
+```
+
+**A call with no token is refused locally rather than sent.** Every path that
+builds an `Authorization` header checks first, so a token source that has not
+produced one yet raises `InvalidCredentialsException` instead of putting
+`Bearer undefined` on the wire — which could only ever come back a 401, a round
+trip spent to be told what you already know. `GeoPlacesClient` asks `refreshToken` first, so a
+client whose token simply has not arrived yet still works.
 
 #### GeoPlaces Adapter
 

--- a/src/client/GeoPlacesClient.ts
+++ b/src/client/GeoPlacesClient.ts
@@ -1,6 +1,6 @@
 import debug from 'debug'
 import { resolveEndpoint } from '../transport/endpoints.js'
-import { isTokenRejected } from '../transport/errors.js'
+import { isTokenRejected, noTokenAvailable } from '../transport/errors.js'
 import type { RequestOptions } from '../transport/http.js'
 import { requestJson } from '../transport/http.js'
 import type { ClientConfig, GeoPlacesCommand } from '../types/index.js'
@@ -53,8 +53,31 @@ export class GeoPlacesClient {
   }
 
   /**
-   * @param options `signal` to cancel, `timeoutMs` per attempt, `retry: false`
-   *   to disable the retry loop. Every failure throws LocationServiceException.
+   * A token to send, or a refusal — never `undefined`.
+   *
+   * `refreshToken` is asked only when there is nothing at all in hand, so a
+   * client configured the ordinary way pays nothing for this.
+   */
+  private async ensureToken(): Promise<string> {
+    // `||`, not `??`: an empty string is a token source with nothing to give,
+    // not a decision to send an empty one. With `??` it survived the coalesce,
+    // skipped `refreshToken`, and then failed the check two lines below — so
+    // `getToken: () => undefined` got the refresh ask and `getToken: () => ''`
+    // did not, which is a distinction no caller means to draw.
+    const token =
+      this.currentToken() || (await this.clientConfig.refreshToken?.())
+    if (!token) {
+      throw noTokenAvailable(
+        'the client has no token yet. Pass `token`, or a `getToken`/`refreshToken` that has one.',
+      )
+    }
+    return token
+  }
+
+  /**
+   * @param options `signal` to cancel, `timeoutMs` per attempt,
+   *   `overallTimeoutMs` for the whole call, `retry: false` to disable the
+   *   retry loop. Every failure throws LocationServiceException.
    */
   async send<TInput, TOutput>(
     command: TInput,
@@ -62,7 +85,15 @@ export class GeoPlacesClient {
   ): Promise<TOutput> {
     const cmd = command as unknown as GeoPlacesCommand
     const url = `${this.clientConfig.apiUrl}${resolveEndpoint(cmd)}`
-    const token = this.currentToken()
+
+    // The fifth and last place in this package that turns a token into an
+    // `Authorization` header, and the last one that would send `Bearer
+    // undefined` (#37). The 401 self-heal below cannot cover this case — it
+    // needs a request to have been rejected first — so a client whose token
+    // source has not produced one yet spent a whole round trip to learn
+    // something it already knew. Ask the refresh source instead, and refuse if
+    // there is still nothing.
+    const token = await this.ensureToken()
 
     try {
       return await this.dispatch<TOutput>(url, token, cmd, options)
@@ -77,8 +108,8 @@ export class GeoPlacesClient {
       const fresh =
         (await this.clientConfig.refreshToken?.()) ?? this.currentToken()
 
-      // Nothing new to send. Repeating the request would fail identically, and
-      // be billed identically.
+      // Nothing new to send. Repeating the request would fail identically — a
+      // second round trip for the same 401.
       if (!fresh || fresh === token) throw err
 
       log(
@@ -91,7 +122,7 @@ export class GeoPlacesClient {
 
   private dispatch<TOutput>(
     url: string,
-    token: string | undefined,
+    token: string,
     cmd: GeoPlacesCommand,
     options?: SendOptions,
   ): Promise<TOutput> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,12 @@
 export { GeoPlacesClient } from './client/GeoPlacesClient.js'
 export type { SendOptions } from './client/GeoPlacesClient.js'
 
-// Transport options — cancellation, per-attempt timeout, retry policy
-export { DEFAULT_MAX_ATTEMPTS, DEFAULT_TIMEOUT_MS } from './transport/http.js'
+// Transport options — cancellation, per-attempt timeout, overall budget, retry
+export {
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_OVERALL_TIMEOUT_MS,
+  DEFAULT_TIMEOUT_MS,
+} from './transport/http.js'
 export type { RequestOptions } from './transport/http.js'
 
 // Token refresh policy — shared by the server provider and the React provider

--- a/src/maps/mapStyle.ts
+++ b/src/maps/mapStyle.ts
@@ -1,6 +1,8 @@
 import type { StyleSpecification } from 'maplibre-gl'
 
-import { parseErrorResponse } from '../transport/errors.js'
+import { noTokenAvailable } from '../transport/errors.js'
+import type { RequestOptions } from '../transport/http.js'
+import { requestJson } from '../transport/http.js'
 import type {
   Buildings,
   ColorScheme,
@@ -99,6 +101,7 @@ export function buildMapStyleUrl(
  * @param mapStyle - Map style name (e.g. 'Standard', 'Monochrome', 'Satellite', 'Hybrid')
  * @param getToken - Callback returning the current auth token
  * @param options - Style options; `language` is applied to the descriptor, all others become URL params
+ * @param request - Transport options: `signal` to cancel, `timeoutMs`, `overallTimeoutMs`, `retry`
  * @returns Modified MapLibre StyleSpecification object
  *
  * @example
@@ -110,40 +113,44 @@ export async function fetchMapStyle(
   mapStyle: MapStyle,
   getToken: () => string | undefined,
   options: MapStyleOptions & { language?: string } = {},
+  request: RequestOptions = {},
 ): Promise<StyleSpecification> {
   const { language, ...styleOptions } = options
   const url = buildMapStyleUrl(apiUrl, mapStyle, styleOptions)
 
   const token = getToken()
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/json',
-    },
-  })
-
-  if (!response.ok) {
-    // Read the body. The API sends `{message, code, requestId}` and the message
-    // is the whole point of it — for a style request it is Amazon's own
-    // sentence, forwarded verbatim by location-service-api#89:
-    //
-    //   400 "Traffic is not supported for style."
-    //   400 "light is not a supported color scheme for style Standard."
-    //
-    // This used to throw `Failed to fetch map style: 400`, discarding all of it
-    // two lines before anyone could read it — the same defect #89 fixed in the
-    // API, one layer up. Reuses parseErrorResponse so a style failure arrives as
-    // the same LocationServiceException as every other call in this package,
-    // with `code`, `statusCode` and `requestId` intact.
-    throw parseErrorResponse(
-      response.status,
-      response.statusText,
-      await response.text(),
-      response.headers,
+  // `Bearer undefined` used to go out here, and came back as a 401 the caller
+  // had to work backwards from — a whole round trip for a request that was
+  // never going to succeed (#37).
+  if (!token) {
+    throw noTokenAvailable(
+      'getToken() returned nothing, so no style request was sent. Check the token provider has finished initialising.',
     )
   }
 
-  const style = (await response.json()) as StyleSpecification
+  // Through the shared transport, not a bare fetch: this gets the same
+  // per-attempt timeout, overall budget, cancellation and retry as every other
+  // call in the package, and the same error type on the way out. It also keeps
+  // the API's own message, which is the whole point of reading the body — for
+  // a style request that sentence is Amazon's, forwarded verbatim by
+  // location-service-api#89:
+  //
+  //   400 "Traffic is not supported for style."
+  //   400 "light is not a supported color scheme for style Standard."
+  //
+  // This used to throw `Failed to fetch map style: 400`, discarding all of it
+  // two lines before anyone could read it — the same defect #89 fixed in the
+  // API, one layer up.
+  const style = await requestJson<StyleSpecification>(
+    url,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+    },
+    request,
+  )
 
   if (language) {
     applyLanguageToDescriptor(style, language)

--- a/src/maps/staticMap.ts
+++ b/src/maps/staticMap.ts
@@ -1,4 +1,6 @@
-import { parseErrorResponse } from '../transport/errors.js'
+import { noTokenAvailable } from '../transport/errors.js'
+import type { RequestOptions } from '../transport/http.js'
+import { requestBlob } from '../transport/http.js'
 import type {
   ColorScheme,
   LabelSize,
@@ -143,6 +145,7 @@ export function buildStaticMapUrl(
  * @param apiUrl   Base URL of the Location Service API
  * @param options  Render options; exactly one of center / boundingBox / boundedPositions
  * @param getToken Callback returning the current auth token
+ * @param request  Transport options: `signal` to cancel, `timeoutMs`, `overallTimeoutMs`, `retry`
  *
  * @example
  * const blob = await fetchStaticMap(API_URL, {
@@ -155,25 +158,31 @@ export async function fetchStaticMap(
   apiUrl: string,
   options: StaticMapOptions,
   getToken: () => string | undefined,
+  request: RequestOptions = {},
 ): Promise<Blob> {
-  const response = await fetch(buildStaticMapUrl(apiUrl, options), {
-    headers: {
-      Authorization: `Bearer ${getToken()}`,
-      Accept: staticMapAccept(options.style),
-    },
-  })
-
-  if (!response.ok) {
-    // Same treatment as fetchMapStyle: the API's {message, code, requestId} is
-    // the useful part, and a bare "failed: 400" throws it away. The messages
-    // here are specific and actionable -- "'width' and 'height' are required",
-    // "Only one of center, bounding-box or bounded-positions may be set".
-    throw parseErrorResponse(
-      response.status,
-      response.statusText,
-      await response.text(),
+  const token = getToken()
+  // The same guard as fetchMapStyle and the server connector: a render is not
+  // worth requesting without a token to send (#37).
+  if (!token) {
+    throw noTokenAvailable(
+      'getToken() returned nothing, so no static map was requested. Check the token provider has finished initialising.',
     )
   }
 
-  return response.blob()
+  // Through the shared transport, so a static map gets the timeout, budget,
+  // cancellation and retry every other call has -- and its failures arrive as
+  // LocationServiceException rather than as a raw TypeError. The API's own
+  // {message, code, requestId} survives, which matters here: the messages are
+  // specific and actionable -- "'width' and 'height' are required", "Only one
+  // of center, bounding-box or bounded-positions may be set".
+  return requestBlob(
+    buildStaticMapUrl(apiUrl, options),
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: staticMapAccept(options.style),
+      },
+    },
+    request,
+  )
 }

--- a/src/server/LocationServiceConnector.ts
+++ b/src/server/LocationServiceConnector.ts
@@ -1,7 +1,7 @@
 import debug from 'debug'
 import { LocationServiceException } from '../errors/LocationServiceException.js'
 import { resolveEndpoint } from '../transport/endpoints.js'
-import { isTokenRejected } from '../transport/errors.js'
+import { isTokenRejected, noTokenAvailable } from '../transport/errors.js'
 import type { RequestOptions } from '../transport/http.js'
 import { requestJson } from '../transport/http.js'
 import type { GeoPlacesCommand } from '../types/index.js'
@@ -89,6 +89,13 @@ function headerValue(
  * spelling of it survives the merge.
  */
 const SYSTEM_HEADERS = ['origin', 'content-type', 'authorization']
+
+/**
+ * What to check when the token source comes up empty. The guard itself is
+ * shared with the map fetches (`noTokenAvailable`); only the advice differs,
+ * and on this path the answer is always the credentials.
+ */
+const NO_TOKEN_ADVICE = 'check clientId/clientSecret configuration'
 
 /** The caller's headers minus `names`, however they capitalised them. */
 function withoutHeaders(
@@ -277,7 +284,7 @@ export class LocationServiceConnector {
     options?: SendOptions,
   ): Promise<TOutput> {
     const token = await source.get()
-    if (!token) throw noTokenAvailable()
+    if (!token) throw noTokenAvailable(NO_TOKEN_ADVICE)
 
     try {
       return await this.dispatch<TOutput>(url, token, cmd, options)
@@ -288,8 +295,8 @@ export class LocationServiceConnector {
       // token. That single comparison covers every source: a fixed `token`
       // string, a caller `getToken` that ignores `forceRefresh`, and a cached
       // token the API has revoked before its `exp` all hand back what we
-      // already sent — and re-sending it would be a second doomed request, and
-      // a second billed one.
+      // already sent — and re-sending it would be a second doomed request for
+      // the same answer.
       const fresh = await source.get(true)
       if (!fresh || fresh === token) throw err
 
@@ -357,12 +364,4 @@ function requireApiUrl(explicit?: string): string {
     })
   }
   return apiUrl
-}
-
-function noTokenAvailable(): LocationServiceException {
-  return new LocationServiceException({
-    code: 'InvalidCredentialsException',
-    message: 'No token available — check clientId/clientSecret configuration',
-    details: { source: 'client' },
-  })
 }

--- a/src/server/getClientConfig.ts
+++ b/src/server/getClientConfig.ts
@@ -21,9 +21,33 @@ export interface ServerAuthConfig {
 
 const log = debug('location-client:clientConfig')
 
-// Singleton instance to prevent race conditions
-let tokenProviderInstance: TokenProvider | null = null
-let currentConfig: string | null = null
+/**
+ * How many applications one process keeps token providers for.
+ *
+ * A provider holds a URL, a client id, a secret and one cached JWT, so the
+ * ceiling is about memory containment rather than a tuned working set — 64 is
+ * far above what a single-tenant service needs and far below anything worth
+ * worrying about. An agency past it pays a re-mint for the least recently used
+ * application, which is exactly the behaviour this replaced, but only for the
+ * coldest one instead of for every alternation.
+ */
+export const MAX_CACHED_PROVIDERS = 64
+
+/**
+ * One provider per configuration, most-recently-used last.
+ *
+ * This used to be TWO module-level variables holding a single provider, and a
+ * process serving more than one application therefore evicted the cache on
+ * every alternation: A→B→A→B took a full `/auth/token` round trip per call,
+ * each writing a jti row, all against the one shared token-endpoint throttle.
+ * The hit rate under alternating load was 0% (#39). Nothing leaked between
+ * tenants — each caller closes over the provider it asked for — so what this
+ * fixes is availability and cost, not confidentiality.
+ *
+ * A `Map` iterates in insertion order, so re-inserting on a hit makes the first
+ * key the least recently used, and an LRU needs no other bookkeeping.
+ */
+const tokenProviders = new Map<string, TokenProvider>()
 
 function getTokenProvider(
   apiUrl: string,
@@ -37,20 +61,40 @@ function getTokenProvider(
   // never ends up in a log line (#5).
   const configKey = `${apiUrl}:${clientId}:${createHash('sha256').update(clientSecret).digest('hex').slice(0, 16)}`
 
-  // Reuse existing instance if config matches
-  if (tokenProviderInstance && currentConfig === configKey) {
+  const cached = tokenProviders.get(configKey)
+  if (cached) {
     log('[getTokenProvider] Reusing existing TokenProvider instance')
-    return tokenProviderInstance
+    // Re-insert to mark it most recently used.
+    tokenProviders.delete(configKey)
+    tokenProviders.set(configKey, cached)
+    return cached
   }
 
-  // Create new instance if config changed
   log('[getTokenProvider] Creating new TokenProvider instance')
-  tokenProviderInstance = new TokenProvider({ apiUrl, clientId, clientSecret })
-  currentConfig = configKey
-  return tokenProviderInstance
+  const provider = new TokenProvider({ apiUrl, clientId, clientSecret })
+  tokenProviders.set(configKey, provider)
+
+  if (tokenProviders.size > MAX_CACHED_PROVIDERS) {
+    const leastRecentlyUsed = tokenProviders.keys().next().value
+    /* c8 ignore next — size > 0 here, so the iterator always yields */
+    if (leastRecentlyUsed !== undefined) {
+      log('[getTokenProvider] Evicting the least recently used TokenProvider')
+      tokenProviders.delete(leastRecentlyUsed)
+    }
+  }
+
+  return provider
 }
 
 export interface ServerClientConfig extends ClientConfig {
+  /**
+   * Narrowed back to required. `ClientConfig.token` is optional because a
+   * client can be driven by `getToken`/`refreshToken` alone, but this type is
+   * what `getClientConfig` RESOLVES — it either has a token or it threw — and
+   * widening it would push a needless `string | undefined` onto every consumer
+   * that reads `config.token`.
+   */
+  token: string
   expiresAt?: number
 }
 

--- a/src/transport/errors.ts
+++ b/src/transport/errors.ts
@@ -98,7 +98,9 @@ function statusCode(status: number): string {
  * expired, and API Gateway turns that into a 401. Its other refusals — no
  * domain configured for the application, an Origin the application does not
  * allow — are a Deny policy or a service 403, and a fresh token changes
- * neither. Retrying those would send, and bill, the same doomed request twice.
+ * neither. Retrying those sends the same doomed request twice, for the same
+ * answer — which is the whole cost, since the service meters successful
+ * requests and no error response is billed whatever its status.
  *
  * Shared by both send paths so the browser client and the server connector
  * cannot come to different conclusions about the same response.
@@ -120,4 +122,26 @@ export function parseRetryAfter(
   const date = Date.parse(value)
   if (!Number.isNaN(date)) return Math.max(0, date - Date.now())
   return undefined
+}
+
+/**
+ * No token to send, so nothing is sent.
+ *
+ * Every send path resolves a token before it builds a request, and every one of
+ * them can come up empty — a provider that has not initialised, a server action
+ * that returned nothing, credentials that are not configured. Sending anyway
+ * puts the literal string `Bearer undefined` on the wire, which the API answers
+ * with a 401 the caller then has to work backwards from — a whole round trip,
+ * paid for out of the caller's own deadline, to be told what it already knew.
+ * The map fetches did exactly that until #37.
+ *
+ * `advice` says what to check, because that differs by path: a server connector
+ * wants its client credentials looked at, a browser map wants its token source.
+ */
+export function noTokenAvailable(advice: string): LocationServiceException {
+  return new LocationServiceException({
+    code: 'InvalidCredentialsException',
+    message: `No token available — ${advice}`,
+    details: { source: 'client' },
+  })
 }

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -6,6 +6,26 @@ const log = debug('location-client:transport')
 
 /** Per-attempt timeout. Sits well under the API's own 25 s Lambda ceiling. */
 export const DEFAULT_TIMEOUT_MS = 10_000
+
+/**
+ * Ceiling for the WHOLE call — every attempt plus every wait between them.
+ *
+ * `timeoutMs` bounds an attempt, not a call, and the gap between those two is
+ * where the caller's own deadline disappears. The API answers a spent quota
+ * with `Retry-After: 60`, which the retry loop honoured literally: two waits of
+ * a minute each, so one call could sit for ~120 s — past any Lambda budget,
+ * past any HTTP gateway, and until now uncancellable (#37).
+ *
+ * 30 s is picked to sit just under the old worst case: three default attempts
+ * that all time out, plus their backoff, came to ~30.75 s. The overlap is not
+ * quite nothing — when both earlier attempts burn their full 10 s, the third is
+ * clamped to the ~9.25 s that remain, so a response arriving in its final
+ * ~0.75 s used to succeed and now times out. That window is why this ships in a
+ * MINOR rather than a patch. What it buys is that no call can be made to sit
+ * out a retry hint longer than the caller has.
+ */
+export const DEFAULT_OVERALL_TIMEOUT_MS = 30_000
+
 export const DEFAULT_MAX_ATTEMPTS = 3
 
 const BACKOFF_BASE_MS = 250
@@ -16,6 +36,15 @@ export interface RequestOptions {
   signal?: AbortSignal
   /** Per ATTEMPT, not for the whole call. Default 10 s. */
   timeoutMs?: number
+  /**
+   * The whole call — attempts and the waits between them. Default 30 s.
+   *
+   * No attempt is given more than what is left of it, and a retry that would
+   * have to wait longer than what is left is not made at all: the API's own
+   * error comes back instead, `retryAfterMs` intact, so the caller can decide
+   * whether to queue the work or drop it.
+   */
+  overallTimeoutMs?: number
   /** `false` disables retries entirely. Default 3 attempts = 2 retries. */
   retry?: false | { maxAttempts?: number }
 }
@@ -61,38 +90,87 @@ export function backoffMs(
   return Math.floor(random() * ceiling)
 }
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+/**
+ * Sleep, unless the caller aborts first.
+ *
+ * The timer used to be uncancellable, so an `abort()` during backoff was
+ * ignored until it elapsed — up to a whole `Retry-After` — and the loop only
+ * noticed at the top of the next attempt (#37). Resolving early is all that is
+ * needed: the loop's own pre-attempt check is what raises `AbortedException`,
+ * so exactly one place decides what an abort means.
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) return Promise.resolve()
+  return new Promise((resolve) => {
+    const done = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener('abort', done)
+      resolve()
+    }
+    const timer = setTimeout(done, ms)
+    signal?.addEventListener('abort', done, { once: true })
+  })
+}
+
+/** Turns an OK response into the caller's value. */
+type ReadBody<T> = (response: Response) => Promise<T>
 
 /**
- * One JSON request, with timeout, cancellation and retry.
+ * One request, with timeout, cancellation and retry.
  *
- * Every failure leaves as a LocationServiceException — a fetch rejection
- * becomes `NetworkException` with the original as `cause`, an abort becomes
- * `AbortedException`, a timeout becomes `TimeoutException` with
- * `details.source = 'client'` so it is distinguishable from the API's own 504.
+ * The body is read INSIDE the attempt loop deliberately: a truncated or
+ * malformed body is a failed attempt like any other and earns the same
+ * wrapping and the same retry as a dropped socket. Handing the `Response` back
+ * for the caller to read would move that outside the loop, where a bare
+ * `SyntaxError` escapes as itself.
  */
-export async function requestJson<T>(
+async function request<T>(
   url: string,
   init: RequestInit,
-  options: RequestOptions = {},
+  options: RequestOptions,
+  read: ReadBody<T>,
 ): Promise<T> {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const overallTimeoutMs =
+    options.overallTimeoutMs ?? DEFAULT_OVERALL_TIMEOUT_MS
   const maxAttempts =
     options.retry === false
       ? 1
       : (options.retry?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS)
 
+  // A request budget of zero attempts is a caller mistake, not a policy. It
+  // used to fall straight through the loop and raise `InternalException` for a
+  // request that was never made — an error about our own internals, for their
+  // typo (#37).
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new LocationServiceException({
+      code: 'ValidationException',
+      message: `retry.maxAttempts must be a whole number of at least 1; received ${maxAttempts}`,
+      details: { source: 'client' },
+    })
+  }
+
+  const deadline = Date.now() + overallTimeoutMs
   let lastError: LocationServiceException | undefined
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     // Checked before every attempt: a signal aborted during backoff must not fire one more.
     if (options.signal?.aborted) throw abortedException(options.signal)
 
-    const { signal, cleanup } = attemptSignal(options.signal, timeoutMs)
+    const budget = deadline - Date.now()
+    if (budget <= 0)
+      throw lastError ?? overallTimeoutException(overallTimeoutMs)
+
+    // Never longer than what is left of the call, so the per-attempt timeout
+    // cannot overrun the budget it sits inside.
+    const { signal, cleanup } = attemptSignal(
+      options.signal,
+      Math.min(timeoutMs, budget),
+    )
     try {
       const response = await fetch(url, { ...init, signal })
 
-      if (response.ok) return (await response.json()) as T
+      if (response.ok) return await read(response)
 
       const error = parseErrorResponse(
         response.status,
@@ -102,12 +180,22 @@ export async function requestJson<T>(
       )
       lastError = error
       if (!error.isRetryable || attempt === maxAttempts - 1) throw error
-      log('attempt %d failed (%s), retrying', attempt + 1, error.code)
-      await sleep(
+
+      const wait =
         error.retryAfterMs ??
-          parseRetryAfter(response.headers.get('retry-after')) ??
-          backoffMs(attempt),
-      )
+        parseRetryAfter(response.headers.get('retry-after')) ??
+        backoffMs(attempt)
+
+      // Sitting out a 60 s `Retry-After` inside a 30 s budget only delivers the
+      // same failure after the caller has already given up. Stop now and hand
+      // back what the API said, `retryAfterMs` and all.
+      if (wait >= deadline - Date.now()) {
+        log('not retrying: a %d ms wait outlasts the remaining budget', wait)
+        break
+      }
+
+      log('attempt %d failed (%s), retrying', attempt + 1, error.code)
+      await sleep(wait, options.signal)
     } catch (err) {
       if (err instanceof LocationServiceException) {
         // Already classified above, or thrown on the final attempt.
@@ -118,14 +206,22 @@ export async function requestJson<T>(
       const wrapped = wrapFetchError(err, options.signal)
       lastError = wrapped
       if (!wrapped.isRetryable || attempt === maxAttempts - 1) throw wrapped
+
+      const wait = backoffMs(attempt)
+      if (wait >= deadline - Date.now()) {
+        log('not retrying: a %d ms wait outlasts the remaining budget', wait)
+        break
+      }
+
       log('attempt %d failed (%s), retrying', attempt + 1, wrapped.code)
-      await sleep(backoffMs(attempt))
+      await sleep(wait, options.signal)
     } finally {
       cleanup()
     }
   }
 
-  /* c8 ignore next */
+  // Reached when the budget ran out before another attempt could be made, so
+  // `lastError` is the API's own answer and is the useful thing to throw.
   throw (
     lastError ??
     new LocationServiceException({
@@ -135,12 +231,60 @@ export async function requestJson<T>(
   )
 }
 
+/**
+ * One JSON request, with timeout, cancellation and retry.
+ *
+ * Every failure leaves as a LocationServiceException — a fetch rejection
+ * becomes `NetworkException` with the original as `cause`, an abort becomes
+ * `AbortedException`, a timeout becomes `TimeoutException` with
+ * `details.source = 'client'` so it is distinguishable from the API's own 504.
+ */
+export function requestJson<T>(
+  url: string,
+  init: RequestInit,
+  options: RequestOptions = {},
+): Promise<T> {
+  return request<T>(
+    url,
+    init,
+    options,
+    (response) => response.json() as Promise<T>,
+  )
+}
+
+/**
+ * One request answered as a Blob — the static map path.
+ *
+ * Exists so the two map fetches are not the only calls in the package without
+ * a timeout, a retry or a signal: they used their own bare `fetch`, so a
+ * network fault there escaped as a raw `TypeError` while the identical fault on
+ * any other call arrived as `NetworkException` (#37).
+ */
+export function requestBlob(
+  url: string,
+  init: RequestInit,
+  options: RequestOptions = {},
+): Promise<Blob> {
+  return request(url, init, options, (response) => response.blob())
+}
+
 function abortedException(signal?: AbortSignal): LocationServiceException {
   return new LocationServiceException({
     code: 'AbortedException',
     message: 'Request was aborted by the caller',
     details: { source: 'client' },
     cause: signal?.reason,
+  })
+}
+
+/** The call's own budget elapsed, rather than one attempt's timeout. */
+function overallTimeoutException(
+  overallTimeoutMs: number,
+): LocationServiceException {
+  return new LocationServiceException({
+    code: 'TimeoutException',
+    message: `Request exceeded its overall timeout of ${overallTimeoutMs} ms`,
+    details: { source: 'client' },
   })
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,14 +1,31 @@
 // Custom types not provided by AWS SDK
 
+/**
+ * At least one of `token`, `getToken` or `refreshToken` must supply a token, or
+ * `send` refuses locally with `InvalidCredentialsException` rather than putting
+ * `Bearer undefined` on the wire (#37).
+ *
+ * `token` is optional because a client driven purely by a provider — the shape
+ * `@chaosity/location-client-react` uses — has nothing to put there at
+ * construction time, and was previously forced to invent a placeholder. It is
+ * still required on `ServerClientConfig`, which is a RESULT rather than a
+ * configuration: `getClientConfig` always resolves one.
+ */
 export interface ClientConfig {
   apiUrl: string
-  token: string
+  token?: string
   /** Optional callback to get the current token dynamically. When provided,
    *  called on every request so token updates are reflected without recreating the client. */
   getToken?: () => string | undefined
   /**
    * Asked for a replacement AFTER the API has rejected the current token with a
-   * 401, so the request can be retried once instead of failing.
+   * 401, so the request can be retried once instead of failing — and, since
+   * #37, asked once BEFORE the first send when neither `getToken` nor `token`
+   * yields anything, so a client whose token has not arrived yet does not spend
+   * a round trip on `Bearer undefined` to learn that. Both calls mean the same
+   * thing to an implementor — "give me a usable token" — so a `refreshToken`
+   * that mints or awaits one needs no change; only one that assumes every
+   * invocation follows a 401 does.
    *
    * Separate from `getToken` because that one is synchronous by contract — it
    * is read while a request is being built and cannot await anything, so it can

--- a/test/client-token-retry.test.ts
+++ b/test/client-token-retry.test.ts
@@ -12,7 +12,7 @@ import { GeoPlacesClient } from '../src/client/GeoPlacesClient'
  * rotated, before its `exp`: every request 401'd until the 60 s refresh buffer
  * elapsed on its own. `refreshToken` is the async escape hatch, and the guard
  * that matters is the one that DOESN'T retry, because a repeat of a doomed
- * request is a second billed request.
+ * request is a second round trip for the same answer.
  */
 
 const API = 'https://api.test'
@@ -199,5 +199,75 @@ describe('and NOT retried when there is nothing new to send', () => {
     const bodies = fetchMock.mock.calls.map(([, init]) => JSON.parse(init.body))
     expect(bodies[0].BiasPosition).toEqual([151.215, -33.857])
     expect(bodies[1].BiasPosition).toEqual([151.21537, -33.85681])
+  })
+})
+
+describe('a client with no token at all never sends Bearer undefined (#37)', () => {
+  /**
+   * The 401 self-heal above cannot cover this: it needs a request to have been
+   * REJECTED first. So a client whose token source has not produced one yet
+   * spent a whole round trip on `Authorization: Bearer undefined`, to be told
+   * something it already knew.
+   */
+  it('refuses rather than sending, when nothing can supply a token', async () => {
+    const client = new GeoPlacesClient({ apiUrl: API })
+
+    const err = await client
+      .send(new SearchTextCommand({ QueryText: 'x' }))
+      .catch((e) => e)
+
+    expect(err.code).toBe('InvalidCredentialsException')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('asks refreshToken first, and sends once it has one', async () => {
+    // The provider case: `getToken` is synchronous and has nothing yet, but the
+    // async source can mint one. That is a request worth making.
+    const refreshToken = vi.fn().mockResolvedValue('minted')
+    const client = new GeoPlacesClient({
+      apiUrl: API,
+      getToken: () => undefined,
+      refreshToken,
+    })
+
+    await expect(
+      client.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).resolves.toEqual({ ResultItems: [] })
+
+    expect(refreshToken).toHaveBeenCalledTimes(1)
+    expect(authHeaders()).toEqual(['Bearer minted'])
+  })
+
+  it('treats an empty getToken the same as an absent one', async () => {
+    // `??` let `''` through the coalesce and then failed the check below it, so
+    // `getToken: () => undefined` reached refreshToken and `getToken: () => ''`
+    // did not. Nobody means to draw that distinction.
+    const refreshToken = vi.fn().mockResolvedValue('minted')
+    const client = new GeoPlacesClient({
+      apiUrl: API,
+      getToken: () => '',
+      refreshToken,
+    })
+
+    await expect(
+      client.send(new SearchTextCommand({ QueryText: 'x' })),
+    ).resolves.toEqual({ ResultItems: [] })
+
+    expect(refreshToken).toHaveBeenCalledTimes(1)
+    expect(authHeaders()).toEqual(['Bearer minted'])
+  })
+
+  it('refuses when refreshToken cannot supply one either', async () => {
+    const client = new GeoPlacesClient({
+      apiUrl: API,
+      refreshToken: async () => undefined,
+    })
+
+    const err = await client
+      .send(new SearchTextCommand({ QueryText: 'x' }))
+      .catch((e) => e)
+
+    expect(err.code).toBe('InvalidCredentialsException')
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/test/connector.test.ts
+++ b/test/connector.test.ts
@@ -647,8 +647,8 @@ describe('a 401 is retried exactly once, with a fresh token (#36)', () => {
   })
 
   it('does NOT retry a static token — the second request would be identical', async () => {
-    // And billed. A fixed string cannot be refreshed, so there is nothing to
-    // retry WITH.
+    // And pointless. A fixed string cannot be refreshed, so there is nothing
+    // to retry WITH.
     const { LocationServiceConnector } = await load()
     fetchMock.mockImplementation(async () => unauthorized())
 

--- a/test/get-client-config.test.ts
+++ b/test/get-client-config.test.ts
@@ -58,13 +58,14 @@ let saved: Record<string, string | undefined>
  */
 const load = async () => {
   vi.resetModules()
-  const [{ getClientConfig }, { LocationServiceException }] = await Promise.all(
-    [
-      import('../src/server/getClientConfig'),
-      import('../src/errors/LocationServiceException'),
-    ],
-  )
-  return { getClientConfig, LocationServiceException }
+  const [
+    { getClientConfig, MAX_CACHED_PROVIDERS },
+    { LocationServiceException },
+  ] = await Promise.all([
+    import('../src/server/getClientConfig'),
+    import('../src/errors/LocationServiceException'),
+  ])
+  return { getClientConfig, MAX_CACHED_PROVIDERS, LocationServiceException }
 }
 
 beforeEach(() => {
@@ -324,5 +325,52 @@ describe('the return value stays plain data', () => {
       Object.values(config).some((value) => typeof value === 'function'),
     ).toBe(false)
     expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+})
+
+describe('the cache holds one provider per application, not one in total (#39)', () => {
+  const app = (n: number) => ({
+    apiUrl: 'https://api.test',
+    clientId: `id-${n}`,
+    clientSecret: 's',
+  })
+
+  it('serves alternating applications from cache instead of re-minting each time', async () => {
+    // Two module-level variables held ONE provider, so the slot was evicted on
+    // every alternation: A→B→A→B meant four /auth/token round trips, four jti
+    // rows, all against the one shared token-endpoint throttle. For a process
+    // serving two applications — or an agency serving many — the hit rate was
+    // 0%. No token ever crossed tenants (each caller closes over the provider
+    // it asked for), so what this costs is availability and money.
+    const { getClientConfig } = await load()
+
+    await getClientConfig(app(1))
+    await getClientConfig(app(2))
+    await getClientConfig(app(1))
+    await getClientConfig(app(2))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('stays bounded, and evicts the least recently used rather than the oldest', async () => {
+    const { getClientConfig, MAX_CACHED_PROVIDERS } = await load()
+
+    // Fill it exactly, then touch the first application again so it is the
+    // most recently used and app(1) is the coldest.
+    for (let n = 0; n < MAX_CACHED_PROVIDERS; n++) await getClientConfig(app(n))
+    await getClientConfig(app(0))
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_CACHED_PROVIDERS)
+
+    // One more application pushes the cache over its bound.
+    await getClientConfig(app(MAX_CACHED_PROVIDERS))
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_CACHED_PROVIDERS + 1)
+
+    // The one that was touched survived...
+    await getClientConfig(app(0))
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_CACHED_PROVIDERS + 1)
+
+    // ...and the coldest one is the one that was dropped.
+    await getClientConfig(app(1))
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_CACHED_PROVIDERS + 2)
   })
 })

--- a/test/map-style-errors.test.ts
+++ b/test/map-style-errors.test.ts
@@ -177,3 +177,81 @@ describe('a successful style is still returned untouched', () => {
     expect(style.version).toBe(8)
   })
 })
+
+describe('the style fetch is on the shared transport (#37)', () => {
+  /**
+   * It used to be a bare `fetch`: no timeout, no retry, no signal, and a
+   * network fault escaping as a raw `TypeError` while the identical fault on
+   * any other call in the package arrived as `NetworkException`.
+   */
+  it('refuses without a token rather than sending Bearer undefined', async () => {
+    const spy = vi.fn()
+    vi.stubGlobal('fetch', spy)
+
+    const err = await fetchMapStyle(
+      'https://api.example.com',
+      'Standard',
+      () => undefined,
+    ).catch((e: unknown) => e as LocationServiceException)
+
+    expect(err).toBeInstanceOf(LocationServiceException)
+    expect(err.code).toBe('InvalidCredentialsException')
+    // Not sent at all: `Bearer undefined` is a request that can only 401 — a
+    // round trip spent to be told what the caller already knows.
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('retries a 503 and returns the descriptor it eventually gets', async () => {
+    const spy = vi
+      .fn()
+      .mockImplementationOnce(async () => json(503, { message: 'later' }))
+      .mockImplementationOnce(async () =>
+        json(200, { version: 8, sources: {}, layers: [] }),
+      )
+    vi.stubGlobal('fetch', spy)
+
+    const style = await fetchMapStyle(
+      'https://api.example.com',
+      'Standard',
+      () => 'tok',
+    )
+    expect(style.version).toBe(8)
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports a network fault as NetworkException, not a raw TypeError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('fetch failed')),
+    )
+
+    const err = await fetchMapStyle(
+      'https://api.example.com',
+      'Standard',
+      () => 'tok',
+      {},
+      { retry: false },
+    ).catch((e: unknown) => e as LocationServiceException)
+
+    expect(err).toBeInstanceOf(LocationServiceException)
+    expect(err.code).toBe('NetworkException')
+  })
+
+  it('is cancellable, like every other call', async () => {
+    const spy = vi.fn()
+    vi.stubGlobal('fetch', spy)
+    const controller = new AbortController()
+    controller.abort()
+
+    const err = await fetchMapStyle(
+      'https://api.example.com',
+      'Standard',
+      () => 'tok',
+      {},
+      { signal: controller.signal },
+    ).catch((e: unknown) => e as LocationServiceException)
+
+    expect(err.code).toBe('AbortedException')
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/test/static-map.test.ts
+++ b/test/static-map.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { LocationServiceException } from '../src/errors/LocationServiceException'
 import {
   buildStaticMapUrl,
   fetchStaticMap,
@@ -208,5 +209,79 @@ describe('fetchStaticMap', () => {
     await expect(
       fetchStaticMap(API, { width: 0, height: 0, center: [1, 2] }, token),
     ).rejects.toThrow(/width.*height.*required/i)
+  })
+
+  /**
+   * This was a bare `fetch` too: no timeout, no retry, no signal, and
+   * `Bearer undefined` when the token source had nothing to give (#37).
+   */
+  it('refuses without a token rather than sending Bearer undefined', async () => {
+    const spy = vi.fn()
+    vi.stubGlobal('fetch', spy)
+
+    const err = await fetchStaticMap(
+      API,
+      { width: 640, height: 400, center: [1, 2] },
+      () => undefined,
+    ).catch((e: unknown) => e as LocationServiceException)
+
+    expect(err).toBeInstanceOf(LocationServiceException)
+    expect(err.code).toBe('InvalidCredentialsException')
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('retries a 503 and returns the render it eventually gets', async () => {
+    const spy = vi
+      .fn()
+      .mockImplementationOnce(
+        async () =>
+          new Response(JSON.stringify({ message: 'later' }), { status: 503 }),
+      )
+      .mockImplementationOnce(
+        async () => new Response(new Blob(['png-bytes']), { status: 200 }),
+      )
+    vi.stubGlobal('fetch', spy)
+
+    const blob = await fetchStaticMap(
+      API,
+      { width: 640, height: 400, center: [1, 2] },
+      token,
+    )
+    expect(await blob.text()).toBe('png-bytes')
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports a network fault as NetworkException, not a raw TypeError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('fetch failed')),
+    )
+
+    const err = await fetchStaticMap(
+      API,
+      { width: 640, height: 400, center: [1, 2] },
+      token,
+      { retry: false },
+    ).catch((e: unknown) => e as LocationServiceException)
+
+    expect(err).toBeInstanceOf(LocationServiceException)
+    expect(err.code).toBe('NetworkException')
+  })
+
+  it('is cancellable, like every other call', async () => {
+    const spy = vi.fn()
+    vi.stubGlobal('fetch', spy)
+    const controller = new AbortController()
+    controller.abort()
+
+    const err = await fetchStaticMap(
+      API,
+      { width: 640, height: 400, center: [1, 2] },
+      token,
+      { signal: controller.signal },
+    ).catch((e: unknown) => e as LocationServiceException)
+
+    expect(err.code).toBe('AbortedException')
+    expect(spy).not.toHaveBeenCalled()
   })
 })

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -98,6 +98,101 @@ describe('retry policy', () => {
   })
 })
 
+describe('the call has a budget, not just each attempt (#37)', () => {
+  /**
+   * `timeoutMs` bounds an attempt; nothing bounded the CALL. The API answers a
+   * spent quota with `Retry-After: 60`, which the loop honoured literally — two
+   * waits of a minute inside a request that had seconds to live.
+   */
+  const throttled = (retryAfter: string) =>
+    json(
+      { message: 'quota exceeded', code: 'ThrottlingException' },
+      { status: 429, headers: { 'retry-after': retryAfter } },
+    )
+
+  it('does not sit out a Retry-After longer than the call has left', async () => {
+    fetchMock.mockImplementation(async () => throttled('60'))
+
+    const err = await call().catch((e) => e)
+
+    // One attempt, and the answer comes back now rather than in two minutes.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(err.code).toBe('ThrottlingException')
+    expect(err.statusCode).toBe(429)
+    // The hint survives, so the caller can queue the work instead of guessing.
+    expect(err.retryAfterMs).toBe(60_000)
+  })
+
+  it('still honours a Retry-After that fits inside the budget', async () => {
+    fetchMock
+      .mockResolvedValueOnce(throttled('0'))
+      .mockResolvedValueOnce(json({ ok: true }))
+
+    await expect(call()).resolves.toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives an attempt no more time than the call has left', async () => {
+    // A 3 s per-attempt timeout inside a 100 ms budget is a 100 ms attempt.
+    fetchMock.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () =>
+            reject(Object.assign(new Error('t'), { name: 'TimeoutError' })),
+          )
+        }),
+    )
+
+    const started = Date.now()
+    const err = await call({
+      timeoutMs: 3_000,
+      overallTimeoutMs: 100,
+      retry: false,
+    }).catch((e) => e)
+
+    expect(err.code).toBe('TimeoutException')
+    expect(Date.now() - started).toBeLessThan(1_000)
+  })
+
+  it('refuses a call with no budget at all before sending anything', async () => {
+    const err = await call({ overallTimeoutMs: 0 }).catch((e) => e)
+
+    expect(err.code).toBe('TimeoutException')
+    expect(err.details).toEqual({ source: 'client' })
+    expect(err.message).toContain('overall timeout')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('honours abort() DURING the wait between attempts', async () => {
+    // The backoff timer used to be uncancellable, so an abort here was ignored
+    // until the wait elapsed — up to a whole Retry-After.
+    fetchMock.mockImplementation(async () => throttled('2'))
+
+    const controller = new AbortController()
+    const started = Date.now()
+    const pending = call({ signal: controller.signal })
+
+    // Let the first attempt fail and the wait actually begin.
+    for (let i = 0; i < 20; i++) await Promise.resolve()
+    controller.abort()
+
+    const err = await pending.catch((e) => e)
+    expect(err.code).toBe('AbortedException')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(Date.now() - started).toBeLessThan(1_000)
+  })
+
+  it('rejects a retry budget of zero instead of blaming its own internals', async () => {
+    // `maxAttempts: 0` fell straight through the loop and raised
+    // `InternalException` for a request that was never made.
+    const err = await call({ retry: { maxAttempts: 0 } }).catch((e) => e)
+
+    expect(err.code).toBe('ValidationException')
+    expect(err.message).toContain('maxAttempts')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
 describe('one error type for everything', () => {
   it('wraps a network fault as NetworkException, keeping the cause', async () => {
     const original = new TypeError('fetch failed')


### PR DESCRIPTION
Closes #37
Closes #39

## #37 — the call had no budget, and two fetches were outside the transport

`timeoutMs` bounded an **attempt**, never the call, and the gap between those two
is where a caller's own deadline disappeared. The API answers a spent quota with
`Retry-After: 60`; honoured literally across two retries, one call could block for
~120 s — past any Lambda budget, past any HTTP gateway, and uncancellable.

- **`overallTimeoutMs`, default 30 s.** No attempt gets more time than the call has
  left, and a wait that would outlast the budget is not taken at all: the API's own
  error comes back with `retryAfterMs` intact, which is more use to a caller than a
  timeout. *(Deviation from the ticket, which says "cap the wait": capping means
  sleeping out the budget and failing anyway.)*
- **Backoff is signal-aware**, so `abort()` is honoured mid-wait rather than up to a
  minute later.
- **`maxAttempts < 1`** is a `ValidationException` rather than a synthetic
  `InternalException` about a request that was never made.
- **`fetchMapStyle` and `fetchStaticMap`** used a bare `fetch` — no timeout, no
  retry, no signal, and a network fault escaping as a raw `TypeError` while the
  identical fault anywhere else arrived as `NetworkException`. Both now go through
  the shared transport. There is exactly one `fetch(` in `src/` and `AGENTS.md`
  states that as the invariant.

### One site beyond the ticket

Sweeping for the missing-token guard found a **fifth** place that interpolates a
possibly-undefined token into an `Authorization` header, which neither ticket
names: `GeoPlacesClient`, the browser's main data path. It now asks `refreshToken`
first — the 401 self-heal cannot cover a request that was never accepted — and
refuses locally if there is still nothing. `ClientConfig.token` becomes optional as
a consequence (a provider-driven client has nothing to put there at construction);
`ServerClientConfig` re-narrows it to required, being a **result** rather than a
configuration.

## #39 — the token cache was one slot

Two module-level variables held one `TokenProvider`, so a process serving two
applications evicted on every alternation: a full `/auth/token` round trip per call,
a jti row each, all against the one shared token-endpoint throttle. Now a bounded
LRU (`MAX_CACHED_PROVIDERS = 64`), re-inserted on a hit so insertion order is the
recency order. No token ever crossed tenants — this was availability and cost.

## Verification

**Automated.** 269 tests / 11 files (was 249). Eleven mutations applied to the final
tree, each reverted byte-exact, each reddening exactly the intended test — including
one whose red is a *timeout*, because without the guard the call really does sit out
the full `Retry-After`.

**Live, sandbox, both directions for #39:**

| | A's tokens across A→B→A→B | `/auth/token` requests |
| --- | --- | --- |
| published 0.7.0 | two different tokens | 4 — `200, 401, 200, 401` |
| this branch | the same token twice | 3 — `200, 401, 401` |

**Live, sandbox, #37 through `nextjs-address-finder-full`** — the one sample that
exercises all five changed paths: style descriptor 200, static map 200, autocomplete
200 → GetPlace 200, server connector `searchText` 200. Zero console errors. Sample
restored to its published version afterwards, manifests byte-identical.

**Not driven:** an over-budget `Retry-After` against the live API (needs a genuinely
exhausted quota) and the missing-token guards in a browser — both unit-covered and
mutation-proven, reviewed rather than observed live.

## Also corrected

A claim that had spread through the comments and the README: that a failed request
is billed to the customer. It is not — the service meters successful requests, so a
401 or a 403 costs a round trip, not money. Fourteen sites corrected, including
several that predate this change. Confirmed by generating a real authorizer 401
against the sandbox and reading its own access-log line back.

## Release

This wants **`/publish-lib location-service-client minor` → 0.8.0**, not a patch. A
quota-exhausted call that used to block ~120 s and eventually return now rejects at
30 s, and a call with no token that used to reach the API now throws locally.
Behaviour that used to resolve and now rejects goes in the minor on `0.x` — it is
the only incompatibility signal consumers get.

Downstream: `location-service-client-react` will want a `^0.8.0` bump, and
chaosity-io/location-service-client-react#22 is filed for the provider comment that
goes with it.

Reviewed by the `ship-reviewer` agent (Fable 5) across three rounds; every finding
taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
