### PR TITLE
Release v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chaosity/location-client",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaosity/location-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Client library for Chaosity Location Service with AWS Location Service compatibility",
   "type": "module",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
`@chaosity/location-client` **0.7.0 → 0.8.0**.

## Why minor, not patch

Two behaviours that used to resolve now reject:

- A quota-exhausted call used to honour `Retry-After: 60` literally across two
  retries and block for ~120 s before returning. It now rejects at the 30 s
  overall budget with the API's own error, `retryAfterMs` intact.
- A call with no token used to reach the API and come back 401. It now throws
  `InvalidCredentialsException` locally without sending anything.

`AGENTS.md`'s own rule: on `0.x` a breaking change goes in the MINOR, because
npm treats each `0.x` minor as incompatible and that is the only protection
consumers get. `^0.7.0` will not resolve `0.8.0`, which is the intended signal.

## Commits since v0.7.0

- `3c6d2d2` Bound the whole call, and stop the token cache thrashing (#37, #39)
  — merged as #48

## Dependency ranges

None moved, and none needed to. This is the base package: it depends on no
chaosity package. Both dependents declare it as a **peer** with an open
`>=0.3.0` floor, which `0.8.0` satisfies, so neither is blocked and neither
silently resolves stale runtime code.

Separately — not a blocker for this release, and deliberately not bundled into
it — both carry a **devDependency** caret that cannot cross the minor:
`location-service-client-react` is on `^0.7.0` and `address-form-sdk-js` on
`^0.3.0`, so each validates against a core older than what consumers resolve.
Those belong in their own repos' changes.

## Verification (§1, on this tree)

`git status` clean on `main`, `git pull --ff-only` already up to date,
`npm ci --dry-run` OK, `npm run lint` OK (eslint + prettier), `npm test`
**269 passed / 11 files**, `npm run build` OK, `npm run smoke` OK — both entry
points load as ESM and CJS, `.` 187/186 exports, `./server` 3/3, nothing
server-only reachable from the root.

The pre-push gate re-ran the whole set plus gitleaks on the way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
