### PR TITLE
Stop stating a test count that every commit falsifies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ working, and swaps SigV4 for this service's own bearer-token auth.
 ```bash
 npm run build       # tsc (ESM) + tsc -p tsconfig.cjs.json (CJS) + the CJS marker
 npm run dev         # tsc --watch
-npm test            # vitest run — 269 tests across 11 files
+npm test            # vitest run
 npm run test:watch  # vitest interactive
 npm run smoke       # loads dist/ as ESM and as CJS — run it after build
 npm run lint        # eslint . AND prettier --check .


### PR DESCRIPTION
A test count in a contributor guide is wrong the next time anyone adds a test, and `npm test` prints the true one on demand. Drop the number, keep the command.

**Verified:** `prettier --check` on the changed file; the repo's pre-push gate (lint, tests, build) ran on push.

Documentation only — no code, no dependency, no config value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
